### PR TITLE
Feature/improve tool routing layer

### DIFF
--- a/docs/HOW_TO/ADDING_A_TOOL.md
+++ b/docs/HOW_TO/ADDING_A_TOOL.md
@@ -5,11 +5,72 @@
 3. **Descriptors:** add a TOML block to `DESCRIPTOR_TOMLS` in `src/tools/specs.rs` (`tool_name`, `short_description`, `when_to_use`, `when_not_to_use`, `routing_hints`, examples). Startup runs `ToolDescriptorRegistry::assert_covers_registered_tools` — **missing descriptor for a registered name fails boot**.
 4. **Gatekeeper:** extend `state_allows_tool` in `src/tools/gatekeeper.rs` for each `AgentState` that may call the tool; update `test_policy_covers_all_current_tools` in the same file when the tool is always registered.
 5. **Arg aliases (optional):** if models often send wrong JSON keys, extend **`normalize_tool_args`** in `gatekeeper.rs` before schema validation.
-6. **ToolRouter (embedding text):** prefer rich **`routing_hints`** in the descriptor TOML (step 3). If the tool truly has no hints in the registry, add a **`fallback_triggers`** arm for your `name()` in **`src/tools/routing_phrases.rs`** — `ToolRouter::enrich_for_routing` pulls from there automatically. Only touch **`src/orchestrator/tool_router.rs`** when adding **global** lexical rules (short-input guard, URL / “visit the page” style web intent), not per-tool paraphrases.
-7. **Tests:** schema / happy path; any filesystem writes under `#[test]` must use **`tempfile`** (workspace rules).
+6. **ToolRouter (embedding text):** prefer rich **`routing_hints`** in the descriptor TOML (step 3). If the tool truly has no hints in the registry, add a **`fallback_triggers`** arm for your `name()` in **`src/tools/routing_phrases.rs`** — `ToolRouter::enrich_for_routing` pulls from there automatically. Only touch **`src/orchestrator/tool_router.rs`** when adding **global** lexical rules (short-input guard, URL / “visit the page” style web intent), not per-tool paraphrases. See **Routing layers** below for offer policy / dialog pairing / affinity.
+7. **Tests:** schema / happy path; any filesystem writes under `#[test]` must use **`tempfile`** (workspace rules). Add a small unit case in `src/orchestrator/routing/` when you introduce a new dialog-pairing or affinity rule.
 8. **Web Tools console:** if the tool belongs to an optional family, add or extend a **`should_register_*`** predicate in [`src/tools/registration.rs`](../../src/tools/registration.rs) and list the tool name in the matching family in [`src/ui/web/tools_config_schema.rs`](../../src/ui/web/tools_config_schema.rs). Add editable config keys to [`family_field_keys`](../../src/ui/web/tools_config_schema.rs) and the merge whitelist in [`src/ui/web/tools_config_merge.rs`](../../src/ui/web/tools_config_merge.rs) when operators should change them from the UI.
 
 For architecture context: [docs/updated_architecture/05_TOOLS_GATEKEEPER_DESCRIPTORS.md](updated_architecture/05_TOOLS_GATEKEEPER_DESCRIPTORS.md).
+
+---
+
+## Routing layers (where to put what)
+
+Tool **offer** selection is no longer “cosine ≥ threshold → lock GBNF onto those names” alone. Flow:
+
+```text
+user text
+  → ToolRouter (embeddings + lexical injects)     src/orchestrator/tool_router.rs
+  → RoutingSignals                                 src/orchestrator/routing/signals.rs
+  → decide() / dialog pairing / demotion / margin  src/orchestrator/routing/{policy,dialog}.rs
+  → RoutingOffer / RoutingDecision                 src/orchestrator/routing/decision.rs
+  → slim overlays (cap, web:find, moltbook latch)  src/orchestrator/routing/overlays.rs
+  → slim prompt + GBNF subset                      step.rs + llama_gbnf_subset.rs
+```
+
+Logs carry `rule_id` and `offer_kind` on pre-LLM routing events — grep those when debugging.
+
+### Checklist by change type
+
+| You are adding / changing… | Put it here |
+|---|---|
+| Paraphrases the model should **embed toward** this tool | `routing_hints` in `specs.rs` (preferred). Keep `routing_phrases.rs` fallbacks aligned if you touch them. |
+| **Global** lexical force (URL → `web:fetch`, news phrases, Moltbook brand floor) | `tool_router.rs` only |
+| Prefix affinity for near-tie **cluster unions** (e.g. `agenda`∪`clock`∪`calendar` = `time`) | `routing/clusters.rs` → `affinity_group` |
+| Follow-up after a **successful** tool (“delete that email”, “cancel that meeting”) | `routing/signals.rs` (cues) + `routing/dialog.rs` (ordered rules). Agenda wins over mail/calendar/doc. |
+| Weak lone-hit demotion / margin / unsure fallback knobs | Config: `tool_match_threshold`, `tool_single_hit_floor`, `tool_match_margin`, `tool_unsure_fallback`. Logic: `routing/policy.rs` |
+| Slim map ↔ GBNF pairing (`web:find` with fetch, `doc:read`→`vault:write`, moltbook latch) | `routing/overlays.rs` (single source; `llama_gbnf_subset` re-exports) |
+| Decision type / log labels | `routing/decision.rs` |
+
+### Hint hygiene (do this when writing `routing_hints`)
+
+- Prefer **domain-anchored** phrases: `"delete agenda item"`, `"delete that email"`, `"cancel meeting"`, `"search on Moltbook"`, `"search the web"`.
+- Avoid bare bombs that collide across domains: lone `"remove"`, `"delete"`, `"reply"`, `"alarm"`, `"what is happening"`, `"find about"`.
+- **Clock vs agenda:** wake-only / “no todo” for `clock:alarm`; “remind me to …” / errand framing for `agenda:remind_at`.
+- **Doc delete:** keep `"document"` / `"pdf"` / `"unindex"` / `"ingested"` — never bare `"remove it"` (agenda dialog pairing owns that deictic).
+- **Moltbook:** every hint should mention Moltbook/submolt so brand-less web search does not bleed.
+
+### Dialog pairing rules of thumb
+
+Pattern (see `routing/dialog.rs`):
+
+1. Recent successful tools include `prefix:*` (session-scoped on the orchestrator).
+2. User text matches **domain-anchored** continuation cues in `signals.rs`.
+3. Offer that domain’s cluster (preferred tools first) — **not** the full time-affinity dump for calendar.
+4. Doc pairing requires document vocabulary; bare “remove it” after `doc:list` must **not** steal from agenda.
+
+Priority today: **agenda → mail → calendar → gated doc**.
+
+### Config operators care about
+
+| Knob | Default | Role |
+|---|---|---|
+| `tool_match_threshold` | `0.50` | Cosine floor for router hits |
+| `tool_single_hit_floor` | `0.58` | Lone hit below this is demoted (avoids GBNF lock-in) |
+| `tool_match_margin` | `0.05` | Near-tie window for affinity cluster union |
+| `tool_unsure_fallback` | `full_roster` | After demotion: `full_roster` or `domain_cluster` |
+| `tool_map_offer_cap` | (see config) | Cap on slim/GBNF offered names |
+
+---
 
 ## Background events (alarms, future “hardware interrupts”)
 
@@ -21,6 +82,6 @@ Use the **single presentation outbound channel** (`mpsc::Sender<SessionEvent>` i
    - **Web + Discord:** when a multiplexer is active, `src/presentation/multiplex.rs` relays `SystemAlarm` to **`user_action_tx`** once and fans out `SessionEvent` copies as configured — follow that pattern so alarms are not duplicated.
 3. **`chat_session`** owns the task that receives **`UserAction`** on its channel, applies `SYSTEM_ALARM_PREFIX` for injects (`src/presentation/mod.rs`), and calls `orchestrator.step`. This path does not use the idle **heartbeat** `watch` interrupt; it does not cancel an in-flight LLM generation unless your design adds that explicitly.
 
-**Lexical note:** injected alarm lines are short; `ToolRouter::short_input_guard_conversational_only` tends to treat them as conversational-only for routing — usually desirable for a quick nudge instead of deep tool escalation.
+**Lexical note:** injected alarm lines are short; `ToolRouter::short_input_guard_conversational_only` tends to treat them as conversational-only for routing — usually desirable for a quick nudge instead of deep tool escalation. Moltbook-labeled alarms are an exception (tool mode enabled).
 
 **Wiring reference:** `spawn_alarm_scheduler` is called from **`src/executive/chat_session.rs`** (not the executive router’s thin `Chat` branch). Pair with `clock:timer` / `clock:alarm` and `AlarmPayload` shapes in `src/presentation/mod.rs`.

--- a/docs/HOW_TO/ADDING_A_TOOL.md
+++ b/docs/HOW_TO/ADDING_A_TOOL.md
@@ -40,6 +40,7 @@ Logs carry `rule_id` and `offer_kind` on pre-LLM routing events — grep those w
 | Weak lone-hit demotion / margin / unsure fallback knobs | Config: `tool_match_threshold`, `tool_single_hit_floor`, `tool_match_margin`, `tool_unsure_fallback`. Logic: `routing/policy.rs` |
 | Slim map ↔ GBNF pairing (`web:find` with fetch, `doc:read`→`vault:write`, moltbook latch) | `routing/overlays.rs` (single source; `llama_gbnf_subset` re-exports) |
 | Decision type / log labels | `routing/decision.rs` |
+| URL soft-compel / opinion-only / skip-fetch scorecard | `routing/policy.rs` (`should_soft_compel_web_fetch`); log `PRELLM_URL_SOFT_COMPEL` / `PRELLM_URL_SKIP_FETCH` from `step.rs`. Offline offer goldens: `src/benchmark/routing_offer_fixtures.rs` |
 
 ### Hint hygiene (do this when writing `routing_hints`)
 

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -5,6 +5,7 @@ pub mod isolation;
 pub mod metrics;
 pub mod mutation_tracker;
 pub mod reporter;
+pub mod routing_offer_fixtures;
 pub mod runner;
 pub mod scenarios;
 pub mod speed_probe;
@@ -13,6 +14,10 @@ pub mod suite;
 
 pub use harness::BenchmarkHarness;
 pub use isolation::{BenchmarkIsolation, CleanupReport, IsolationMode, SideEffectFilter, ToolRiskLevel};
+pub use routing_offer_fixtures::{
+    all_routing_offer_fixtures, eval_routing_offer_fixture, run_all_routing_offer_fixtures,
+    RoutingOfferFixture,
+};
 pub use metrics::{
     BenchmarkReport, CleanupConfirmation, FailureAnalysis, FailureType, QualityMetrics, SpeedMetrics,
     StepTiming, SuiteSpeedAggregate,

--- a/src/benchmark/routing_offer_fixtures.rs
+++ b/src/benchmark/routing_offer_fixtures.rs
@@ -1,0 +1,434 @@
+//! Offline routing-offer fixtures (Phase 3 lean).
+//!
+//! Each case is: user text + synthetic router hits + recent successes
+//! → expected `rule_id` and offer constraints.
+//!
+//! **No live llama / embeddings** — hits are fixed so fixtures stay stable.
+//! Live cosine quality still needs a real chat pass after hint edits.
+//!
+//! Run via `cargo test routing_offer_fixtures` (operator: avoid if the
+//! heisenbug is active on this host).
+
+use crate::orchestrator::routing::{
+    apply_routing_policy, RoutingOffer, RoutingPolicyKnobs, UnsureFallback,
+};
+
+/// One golden case for pre-LLM offer policy.
+#[derive(Debug, Clone)]
+pub struct RoutingOfferFixture {
+    pub id: &'static str,
+    pub user_text: &'static str,
+    pub hits: &'static [(&'static str, f32)],
+    pub recent_successful: &'static [&'static str],
+    pub expected_rule_id: &'static str,
+    /// First offered tool name (when non-empty offer).
+    pub expect_first: Option<&'static str>,
+    /// Must appear somewhere in the offer.
+    pub must_include: &'static [&'static str],
+    /// Must not appear in the offer.
+    pub must_exclude: &'static [&'static str],
+    /// When true, offer names must be empty (full roster / conversational empty).
+    pub expect_empty_names: bool,
+    pub unsure_fallback: UnsureFallback,
+}
+
+fn fixture_registry() -> Vec<String> {
+    [
+        "agenda:list",
+        "agenda:remove",
+        "agenda:complete",
+        "agenda:remind_at",
+        "agenda:push",
+        "agenda:remind_self",
+        "clock:now",
+        "clock:alarm",
+        "clock:timer",
+        "calendar:list",
+        "calendar:get",
+        "calendar:delete",
+        "calendar:update",
+        "calendar:create",
+        "doc:ingest",
+        "doc:query",
+        "doc:delete",
+        "doc:list",
+        "doc:read",
+        "web:fetch",
+        "web:find",
+        "web:search",
+        "mail:check",
+        "mail:read",
+        "mail:delete",
+        "mail:move",
+        "mail:write",
+        "mail:digest",
+        "memory:query",
+        "memory:commit",
+        "memory:stage",
+        "memory:staged_list",
+        "memory:commit_all",
+        "moltbook:search",
+        "moltbook:home",
+        "db:find_connections",
+        "vault:read",
+        "news:today",
+        "wiki:summary",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+/// Canonical fixture table (extend here when adding routing rules).
+pub fn all_routing_offer_fixtures() -> Vec<RoutingOfferFixture> {
+    vec![
+        RoutingOfferFixture {
+            id: "demote_lone_weak_doc_ingest",
+            user_text: "please remove that thing from earlier",
+            hits: &[("doc:ingest", 0.505)],
+            recent_successful: &[],
+            expected_rule_id: "UNSURE_FULL_ROSTER",
+            expect_first: None,
+            must_include: &[],
+            must_exclude: &[],
+            expect_empty_names: true,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "unsure_domain_cluster_after_demotion",
+            user_text: "please remove that thing from earlier",
+            hits: &[("doc:ingest", 0.505)],
+            recent_successful: &[],
+            expected_rule_id: "UNSURE_DOMAIN_CLUSTER",
+            expect_first: None, // alphabetical cluster; assert all doc:* below
+            must_include: &["doc:ingest", "doc:list", "doc:delete"],
+            must_exclude: &["agenda:remove"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::DomainCluster,
+        },
+        RoutingOfferFixture {
+            id: "agenda_dialog_after_list",
+            user_text: "please remove that oat milk reminder from my agenda now",
+            hits: &[("doc:ingest", 0.505), ("doc:delete", 0.548)],
+            recent_successful: &["agenda:list"],
+            expected_rule_id: "AGENDA_DIALOG_PAIRING",
+            expect_first: Some("agenda:remove"),
+            must_include: &["agenda:complete", "agenda:list"],
+            must_exclude: &["doc:ingest", "doc:delete"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "mail_delete_after_check",
+            user_text: "please delete that email from my inbox",
+            hits: &[("doc:delete", 0.52), ("agenda:remove", 0.51)],
+            recent_successful: &["mail:check"],
+            expected_rule_id: "MAIL_DIALOG_PAIRING",
+            expect_first: Some("mail:delete"),
+            must_include: &["mail:check"],
+            must_exclude: &["doc:delete"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "calendar_cancel_after_list",
+            user_text: "please cancel that meeting on my calendar",
+            hits: &[("agenda:remove", 0.55), ("clock:alarm", 0.54)],
+            recent_successful: &["calendar:list"],
+            expected_rule_id: "CALENDAR_DIALOG_PAIRING",
+            expect_first: Some("calendar:delete"),
+            must_include: &["calendar:list"],
+            must_exclude: &["agenda:remove", "clock:alarm"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "doc_anchored_delete_after_list",
+            user_text: "please delete that document from the ingested store",
+            hits: &[("agenda:remove", 0.52)],
+            recent_successful: &["doc:list"],
+            expected_rule_id: "DOC_DIALOG_PAIRING",
+            expect_first: Some("doc:delete"),
+            must_include: &["doc:list"],
+            must_exclude: &["agenda:remove"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "bare_remove_after_doc_list_no_doc_pair",
+            user_text: "please remove it",
+            hits: &[("doc:delete", 0.51)],
+            recent_successful: &["doc:list"],
+            // No dialog pairing → lone weak may demote to full roster
+            expected_rule_id: "UNSURE_FULL_ROSTER",
+            expect_first: None,
+            must_include: &[],
+            must_exclude: &[],
+            expect_empty_names: true,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "clock_agenda_affinity_union",
+            user_text: "please remind me tomorrow morning at ten about the dentist appointment",
+            hits: &[("clock:alarm", 0.61), ("agenda:remind_at", 0.59)],
+            recent_successful: &[],
+            expected_rule_id: "AFFINITY_MARGIN_UNION",
+            expect_first: Some("clock:alarm"),
+            must_include: &["agenda:remind_at", "clock:timer", "agenda:list"],
+            must_exclude: &["doc:ingest", "db:find_connections"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "url_mush_keeps_ranked_no_db_first",
+            user_text: "do you know this repository online? https://github.com/vllm-project/semantic-router",
+            hits: &[
+                ("moltbook:search", 0.586),
+                ("web:search", 0.569),
+                ("memory:query", 0.562),
+                ("doc:query", 0.548),
+                ("memory:commit", 0.543),
+                ("web:fetch", 0.542),
+                ("db:find_connections", 0.540),
+                ("web:find", 0.537),
+            ],
+            recent_successful: &[],
+            expected_rule_id: "RANKED_SUBSET",
+            expect_first: Some("moltbook:search"),
+            must_include: &["web:fetch", "db:find_connections"],
+            must_exclude: &["doc:ingest"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "lexical_fetch_leads_cosine_rank",
+            user_text: "please open this page and summarize: https://eris-system.dev",
+            hits: &[
+                ("doc:ingest", 0.505),
+                ("web:fetch", 1.0),
+                ("web:find", 0.99),
+            ],
+            recent_successful: &[],
+            // Lone weak embed demoted; forced lexical hits survive.
+            expected_rule_id: "LEXICAL_FORCED_ONLY",
+            expect_first: Some("web:fetch"),
+            must_include: &["web:find"],
+            must_exclude: &["doc:ingest"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "mixed_embed_and_lexical_fetch",
+            user_text: "please summarize https://eris-system.dev and relate it to my notes",
+            hits: &[
+                ("memory:query", 0.62),
+                ("web:fetch", 1.0),
+                ("web:find", 0.99),
+            ],
+            recent_successful: &[],
+            expected_rule_id: "MIXED_EMBED_AND_LEXICAL",
+            expect_first: Some("web:fetch"),
+            must_include: &["memory:query", "web:find"],
+            must_exclude: &[],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "strong_single_vault_read",
+            user_text: "please read the vault note at notes/today.md if it exists",
+            hits: &[("vault:read", 0.72)],
+            recent_successful: &[],
+            expected_rule_id: "SINGLE_STRONG_HIT",
+            expect_first: Some("vault:read"),
+            must_include: &["vault:read"],
+            must_exclude: &[],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "agenda_beats_mail_when_both_recent",
+            user_text: "please remove that from my agenda",
+            hits: &[("mail:delete", 0.60)],
+            recent_successful: &["mail:check", "agenda:list"],
+            expected_rule_id: "AGENDA_DIALOG_PAIRING",
+            expect_first: Some("agenda:remove"),
+            must_include: &["agenda:list"],
+            must_exclude: &["mail:delete"],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "weather_strong_ranked",
+            user_text: "what is the current weather forecast for Berlin Germany right now",
+            hits: &[
+                ("weather:current", 0.704),
+                ("weather:forecast", 0.697),
+                ("db:find_connections", 0.652),
+            ],
+            recent_successful: &[],
+            expected_rule_id: "RANKED_SUBSET",
+            expect_first: Some("weather:current"),
+            must_include: &["weather:forecast"],
+            must_exclude: &[],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "mail_check_ranked",
+            user_text: "please check whether I have any unread email in my inbox",
+            hits: &[
+                ("mail:check", 0.705),
+                ("mail:read", 0.617),
+                ("mail:digest", 0.568),
+            ],
+            recent_successful: &[],
+            expected_rule_id: "RANKED_SUBSET",
+            expect_first: Some("mail:check"),
+            must_include: &["mail:read"],
+            must_exclude: &[],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+        RoutingOfferFixture {
+            id: "doc_list_strong_ranked",
+            user_text: "please list all of my ingested documents in the document store",
+            hits: &[
+                ("doc:list", 0.789),
+                ("doc:ingest", 0.739),
+                ("doc:delete", 0.685),
+            ],
+            recent_successful: &[],
+            expected_rule_id: "RANKED_SUBSET",
+            expect_first: Some("doc:list"),
+            must_include: &["doc:ingest"],
+            must_exclude: &[],
+            expect_empty_names: false,
+            unsure_fallback: UnsureFallback::FullRoster,
+        },
+    ]
+}
+
+/// Evaluate one fixture; returns `Ok(())` or an error string.
+pub fn eval_routing_offer_fixture(fx: &RoutingOfferFixture) -> Result<(), String> {
+    let hits: Vec<(String, f32)> = fx
+        .hits
+        .iter()
+        .map(|(n, s)| ((*n).to_string(), *s))
+        .collect();
+    let recent: Vec<String> = fx
+        .recent_successful
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    let mut reg = fixture_registry();
+    // Ensure weather tools exist for weather fixture.
+    for w in ["weather:current", "weather:forecast"] {
+        if !reg.iter().any(|n| n == w) {
+            reg.push(w.to_string());
+        }
+    }
+
+    let knobs = RoutingPolicyKnobs {
+        single_hit_floor: 0.58,
+        match_margin: 0.05,
+        unsure_fallback: fx.unsure_fallback,
+    };
+    let decision = apply_routing_policy(fx.user_text, &hits, &recent, &reg, knobs);
+    let names = decision.matched_tool_names();
+
+    if decision.rule_id != fx.expected_rule_id {
+        return Err(format!(
+            "[{}] rule_id: got {}, want {}",
+            fx.id, decision.rule_id, fx.expected_rule_id
+        ));
+    }
+    if fx.expect_empty_names {
+        if !names.is_empty() {
+            return Err(format!(
+                "[{}] expected empty names (full roster), got {names:?}",
+                fx.id
+            ));
+        }
+        return Ok(());
+    }
+    if let Some(first) = fx.expect_first {
+        match names.first() {
+            Some(n) if n == first => {}
+            other => {
+                return Err(format!(
+                    "[{}] expect_first={first}, got {other:?} (full={names:?})",
+                    fx.id
+                ));
+            }
+        }
+    }
+    for must in fx.must_include {
+        if !names.iter().any(|n| n == must) {
+            return Err(format!(
+                "[{}] missing must_include {must} in {names:?}",
+                fx.id
+            ));
+        }
+    }
+    for bad in fx.must_exclude {
+        if names.iter().any(|n| n == bad) {
+            return Err(format!(
+                "[{}] must_exclude {bad} present in {names:?}",
+                fx.id
+            ));
+        }
+    }
+    // Ranked URL mush: fetch before db when both present.
+    if fx.id == "url_mush_keeps_ranked_no_db_first" {
+        let fetch = names.iter().position(|n| n == "web:fetch");
+        let db = names.iter().position(|n| n == "db:find_connections");
+        match (fetch, db) {
+            (Some(f), Some(d)) if f < d => {}
+            other => {
+                return Err(format!(
+                    "[{}] web:fetch should rank before db:find_connections, got {other:?} in {names:?}",
+                    fx.id
+                ));
+            }
+        }
+    }
+    // Domain-cluster demotion: first may be any doc:* after cosine re-rank of cluster.
+    if fx.id == "unsure_domain_cluster_after_demotion" {
+        if !matches!(decision.offer, RoutingOffer::DomainCluster { .. }) {
+            return Err(format!("[{}] expected DomainCluster offer", fx.id));
+        }
+        if !names.iter().all(|n| n.starts_with("doc:")) {
+            return Err(format!("[{}] expected only doc:* tools, got {names:?}", fx.id));
+        }
+    }
+    Ok(())
+}
+
+/// Run the full table; returns `(passed, failures)`.
+pub fn run_all_routing_offer_fixtures() -> (usize, Vec<String>) {
+    let mut passed = 0usize;
+    let mut failures = Vec::new();
+    for fx in all_routing_offer_fixtures() {
+        match eval_routing_offer_fixture(&fx) {
+            Ok(()) => passed += 1,
+            Err(e) => failures.push(e),
+        }
+    }
+    (passed, failures)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_routing_offer_fixtures_pass() {
+        let (passed, failures) = run_all_routing_offer_fixtures();
+        assert!(
+            failures.is_empty(),
+            "routing offer fixtures: {passed} passed, failures:\n{}",
+            failures.join("\n")
+        );
+        assert!(passed >= 12, "expected at least 12 fixtures, got {passed}");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -818,6 +818,15 @@ pub struct AppConfig {
     pub vault_read_ratio: f32,
     /// Cosine similarity floor for ToolRouter pre-LLM semantic matches (0.0–1.0).
     pub tool_match_threshold: f32,
+    /// Lone semantic hit below this score is demoted (empty → full roster) to avoid GBNF lock-in.
+    /// Lexical forced hits (≥ ~0.99) are never demoted. Default mirrors the Moltbook soft floor (0.58).
+    #[serde(default = "default_tool_single_hit_floor")]
+    pub tool_single_hit_floor: f32,
+    /// When top−second score gap is below this margin and the near-ties span multiple domains
+    /// (e.g. `clock:` vs `agenda:`), offer the union of those domain clusters instead of locking
+    /// onto the single top tool.
+    #[serde(default = "default_tool_match_margin")]
+    pub tool_match_margin: f32,
     /// Number of semantic-router hits that receive extra “when to use” descriptor text in tool mode.
     #[serde(default = "default_tool_descriptor_jit_top_k")]
     pub tool_descriptor_jit_top_k: usize,
@@ -1037,6 +1046,14 @@ fn default_slim_tool_prompt() -> bool {
 /// With slim tool prompt + semantic hits, cap how many matched tools appear in the phrase map; `0` = no cap.
 fn default_tool_map_offer_cap() -> usize {
     0
+}
+
+fn default_tool_single_hit_floor() -> f32 {
+    0.58
+}
+
+fn default_tool_match_margin() -> f32 {
+    0.05
 }
 
 /// When true, chat startup fails if Qdrant is unreachable after retries.
@@ -1778,6 +1795,8 @@ impl Default for AppConfig {
             news_today_deep_fetch_max_default: default_news_today_deep_fetch_max(),
             vault_read_ratio: 0.5,
             tool_match_threshold: 0.50,
+            tool_single_hit_floor: default_tool_single_hit_floor(),
+            tool_match_margin: default_tool_match_margin(),
             tool_descriptor_jit_top_k: default_tool_descriptor_jit_top_k(),
             tool_descriptor_jit_max_chars: default_tool_descriptor_jit_max_chars(),
             slim_tool_prompt: default_slim_tool_prompt(),
@@ -2251,6 +2270,8 @@ mod tests {
             (32_768_f32 * 0.9_f32).floor() as usize
         );
         assert_eq!(parsed_config.tool_match_threshold, 0.50);
+        assert_eq!(parsed_config.tool_single_hit_floor, 0.58);
+        assert_eq!(parsed_config.tool_match_margin, 0.05);
         assert_eq!(parsed_config.ollama_daemon.command, "ollama");
         assert_eq!(parsed_config.ollama_daemon.args, vec!["serve"]);
         assert_eq!(parsed_config.unload_ollama_models_on_chat_exit, true);

--- a/src/config.rs
+++ b/src/config.rs
@@ -827,6 +827,10 @@ pub struct AppConfig {
     /// onto the single top tool.
     #[serde(default = "default_tool_match_margin")]
     pub tool_match_margin: f32,
+    /// When a lone weak embed hit is demoted: `"full_roster"` (default) or `"domain_cluster"`
+    /// (expand that tool's prefix cluster instead of opening the full allowed roster).
+    #[serde(default = "default_tool_unsure_fallback")]
+    pub tool_unsure_fallback: String,
     /// Number of semantic-router hits that receive extra “when to use” descriptor text in tool mode.
     #[serde(default = "default_tool_descriptor_jit_top_k")]
     pub tool_descriptor_jit_top_k: usize,
@@ -1054,6 +1058,10 @@ fn default_tool_single_hit_floor() -> f32 {
 
 fn default_tool_match_margin() -> f32 {
     0.05
+}
+
+fn default_tool_unsure_fallback() -> String {
+    "full_roster".into()
 }
 
 /// When true, chat startup fails if Qdrant is unreachable after retries.
@@ -1797,6 +1805,7 @@ impl Default for AppConfig {
             tool_match_threshold: 0.50,
             tool_single_hit_floor: default_tool_single_hit_floor(),
             tool_match_margin: default_tool_match_margin(),
+            tool_unsure_fallback: default_tool_unsure_fallback(),
             tool_descriptor_jit_top_k: default_tool_descriptor_jit_top_k(),
             tool_descriptor_jit_max_chars: default_tool_descriptor_jit_max_chars(),
             slim_tool_prompt: default_slim_tool_prompt(),
@@ -2272,6 +2281,7 @@ mod tests {
         assert_eq!(parsed_config.tool_match_threshold, 0.50);
         assert_eq!(parsed_config.tool_single_hit_floor, 0.58);
         assert_eq!(parsed_config.tool_match_margin, 0.05);
+        assert_eq!(parsed_config.tool_unsure_fallback, "full_roster");
         assert_eq!(parsed_config.ollama_daemon.command, "ollama");
         assert_eq!(parsed_config.ollama_daemon.args, vec!["serve"]);
         assert_eq!(parsed_config.unload_ollama_models_on_chat_exit, true);

--- a/src/orchestrator/core/llama_gbnf_subset.rs
+++ b/src/orchestrator/core/llama_gbnf_subset.rs
@@ -72,6 +72,9 @@ impl GbnfSubsetCache {
 
 /// Single source of truth for the slim offered-tool list: used by both slim prompt
 /// assembly and the per-hop GBNF subset grammar in [`super::step::Orchestrator::step`].
+///
+/// Implementation lives in [`crate::orchestrator::routing::overlays`] so prompt and
+/// grammar cannot drift apart.
 pub(crate) fn slim_offered_tool_names(
     pre_llm_matched_tools: &[String],
     tool_map_offer_cap: usize,
@@ -79,45 +82,13 @@ pub(crate) fn slim_offered_tool_names(
     gatekeeper: &Gatekeeper,
     state: &AgentState,
 ) -> Vec<String> {
-    let mut offered: Vec<String> = if pre_llm_matched_tools.is_empty() {
-        vec![]
-    } else if tool_map_offer_cap == 0 {
-        pre_llm_matched_tools.to_vec()
-    } else {
-        pre_llm_matched_tools
-            .iter()
-            .take(tool_map_offer_cap)
-            .cloned()
-            .collect()
-    };
-
-    if moltbook_overlay_latched && !offered.is_empty() {
-        for name in gatekeeper.allowed_tool_names_with_prefix(state, "moltbook:") {
-            if !offered.contains(&name) {
-                offered.push(name);
-            }
-        }
-    }
-
-    let needs_web_find = offered.iter().any(|n| n == "web:fetch" || n == "web:search");
-    if needs_web_find {
-        let find_allowed = gatekeeper
-            .allowed_tool_names_with_prefix(state, "web:")
-            .into_iter()
-            .any(|n| n == "web:find");
-        if find_allowed && !offered.iter().any(|n| n == "web:find") {
-            offered.push("web:find".to_string());
-        }
-    }
-
-    if offered.iter().any(|n| n == "doc:read")
-        && !offered.iter().any(|n| n == "vault:write")
-        && Gatekeeper::state_allows_tool(state, "vault:write")
-    {
-        offered.push("vault:write".to_string());
-    }
-
-    offered
+    crate::orchestrator::routing::apply_offer_overlays(
+        pre_llm_matched_tools,
+        tool_map_offer_cap,
+        moltbook_overlay_latched,
+        gatekeeper,
+        state,
+    )
 }
 
 #[cfg(test)]

--- a/src/orchestrator/core/orchestrator.rs
+++ b/src/orchestrator/core/orchestrator.rs
@@ -116,6 +116,9 @@ pub struct Orchestrator<E: LlmEngine> {
     pub(super) tool_repeat_failure_streak: HashMap<String, u8>,
     /// Tool names that failed in the current `step()`; used to prioritize recovery JIT skill guidance.
     pub(super) step_failed_tools: HashSet<String>,
+    /// Session-scoped recent successful tool names (newest last, capped). Used by Phase-1
+    /// agenda dialog pairing so “remove it” after `agenda:list` does not lock onto a weak `doc:*` hit.
+    pub(super) recent_successful_tools: Vec<String>,
     /// llama.cpp only: memoized GBNF strings keyed by sorted tool names for per-turn subset grammar.
     pub(super) gbnf_subset_cache: GbnfSubsetCache,
     /// Anti-crawl ledger shared with web tools (reset at chat bootstrap).
@@ -239,6 +242,7 @@ impl<E: LlmEngine> Orchestrator<E> {
             moltbook_browse_ledger: None,
             tool_repeat_failure_streak: HashMap::new(),
             step_failed_tools: HashSet::new(),
+            recent_successful_tools: Vec::new(),
             token_metrics_rx,
             gbnf_subset_cache: GbnfSubsetCache::new(),
             web_ledger,

--- a/src/orchestrator/core/pre_llm_routing.rs
+++ b/src/orchestrator/core/pre_llm_routing.rs
@@ -1,6 +1,6 @@
 use crate::engine::LlmEngine;
 use crate::orchestrator::routing::{
-    apply_routing_policy, RoutingPolicyKnobs,
+    apply_routing_policy, RoutingDecision, RoutingPolicyKnobs, UnsureFallback,
 };
 use crate::orchestrator::tool_router::ToolRouter;
 use crate::presentation::SYSTEM_ALARM_PREFIX;
@@ -10,8 +10,8 @@ use std::time::Instant;
 use super::Orchestrator;
 
 impl<E: LlmEngine> Orchestrator<E> {
-    /// Conversational vs tool mode, plus ordered router names for Tier 1 (Top-K).
-    pub(super) async fn run_pre_llm_routing(&mut self) -> (bool, Vec<String>) {
+    /// Conversational vs tool mode, plus a structured [`RoutingDecision`] for Tier 1.
+    pub(super) async fn run_pre_llm_routing(&mut self) -> RoutingDecision {
         let user_input = self.last_user_content().to_string();
         let turn_seq = self.turn_seq;
 
@@ -23,12 +23,15 @@ impl<E: LlmEngine> Orchestrator<E> {
                 tracing::info!(
                     category = routing_codes::CATEGORY_ROUTING,
                     issue = routing_codes::ISSUE_PRELLM_ALARM_TOOL_ELIGIBLE,
-                    outcome = routing_codes::outcome_from_pre_llm_tuple(true, 0),
+                    outcome = routing_codes::OUTCOME_TOOL_FALLBACK,
                     turn_seq,
+                    rule_id = "ALARM_MOLTBOOK",
+                    offer_kind = "full_roster",
                     tools_needed = true,
                     router_match_count = 0usize,
                     "system alarm prefix with Moltbook label; semantic tool routing enabled"
                 );
+                // Fall through to normal router (tools needed).
             } else {
                 self.last_router_ms = 0;
                 self.last_top_tool_match = None;
@@ -37,11 +40,13 @@ impl<E: LlmEngine> Orchestrator<E> {
                     issue = routing_codes::ISSUE_PRELLM_CONV_ALARM,
                     outcome = routing_codes::OUTCOME_CONVERSATIONAL,
                     turn_seq,
+                    rule_id = "CONV_ALARM",
+                    offer_kind = "conversational",
                     tools_needed = false,
                     router_match_count = 0usize,
                     "system alarm prefix; conversational mode"
                 );
-                return (false, Vec::new());
+                return RoutingDecision::conversational("CONV_ALARM");
             }
         }
 
@@ -53,11 +58,13 @@ impl<E: LlmEngine> Orchestrator<E> {
                 issue = routing_codes::ISSUE_PRELLM_CONV_SHORT_INPUT,
                 outcome = routing_codes::OUTCOME_CONVERSATIONAL,
                 turn_seq,
+                rule_id = "SHORT_INPUT",
+                offer_kind = "conversational",
                 tools_needed = false,
                 router_match_count = 0usize,
                 "short-input guard; conversational mode"
             );
-            return (false, Vec::new());
+            return RoutingDecision::conversational("SHORT_INPUT");
         }
 
         let router_started = Instant::now();
@@ -68,13 +75,15 @@ impl<E: LlmEngine> Orchestrator<E> {
                 tracing::warn!(
                     category = routing_codes::CATEGORY_ROUTING,
                     issue = routing_codes::ISSUE_PRELLM_ROUTER_UNAVAILABLE,
-                    outcome = routing_codes::outcome_from_pre_llm_tuple(true, 0),
+                    outcome = routing_codes::OUTCOME_TOOL_FALLBACK,
                     turn_seq,
+                    rule_id = "ROUTER_UNAVAILABLE",
+                    offer_kind = "full_roster",
                     tools_needed = true,
                     router_match_count = 0usize,
                     "no tool router; roster-only tool mode"
                 );
-                return (true, Vec::new());
+                return RoutingDecision::full_roster("ROUTER_UNAVAILABLE");
             };
             router.match_tools(&user_input).await
         };
@@ -86,13 +95,15 @@ impl<E: LlmEngine> Orchestrator<E> {
                 tracing::info!(
                     category = routing_codes::CATEGORY_ROUTING,
                     issue = routing_codes::ISSUE_PRELLM_SEMANTIC_EMPTY,
-                    outcome = routing_codes::outcome_from_pre_llm_tuple(true, 0),
+                    outcome = routing_codes::OUTCOME_TOOL_FALLBACK,
                     turn_seq,
+                    rule_id = "SEMANTIC_EMPTY",
+                    offer_kind = "full_roster",
                     tools_needed = true,
                     router_match_count = 0usize,
                     "no semantic tool match; tool fallback mode"
                 );
-                (true, Vec::new())
+                RoutingDecision::full_roster("SEMANTIC_EMPTY")
             }
             Ok(matches) => {
                 self.last_router_ms = router_started.elapsed().as_millis() as u64;
@@ -104,44 +115,39 @@ impl<E: LlmEngine> Orchestrator<E> {
                 let knobs = RoutingPolicyKnobs {
                     single_hit_floor: self.config.tool_single_hit_floor,
                     match_margin: self.config.tool_match_margin,
+                    unsure_fallback: UnsureFallback::parse(&self.config.tool_unsure_fallback),
                 };
                 let recent = self.recent_successful_tools.clone();
-                let policy = apply_routing_policy(
-                    &user_input,
-                    &matches,
-                    &recent,
-                    &registered,
-                    knobs,
-                );
-                self.last_top_tool_match = policy
-                    .offered
+                let decision =
+                    apply_routing_policy(&user_input, &matches, &recent, &registered, knobs);
+                let names = decision.matched_tool_names();
+                self.last_top_tool_match = names
                     .first()
                     .cloned()
                     .or_else(|| matches.first().map(|(n, s)| format!("{n}({s:.3})")));
-                let names = policy.offered;
                 let router_match_count = names.len();
-                let issue = if policy.reason == "EMPTY_AFTER_POLICY" && !matches.is_empty() {
-                    routing_codes::ISSUE_PRELLM_POLICY_REWRITE
-                } else if policy.reason == "AGENDA_DIALOG_PAIRING"
-                    || policy.reason == "MARGIN_CLUSTER_OR_SUBSET"
-                {
-                    routing_codes::ISSUE_PRELLM_POLICY_REWRITE
-                } else {
-                    routing_codes::ISSUE_PRELLM_SEMANTIC_HIT
+                let issue = match decision.rule_id {
+                    "SINGLE_STRONG_HIT" | "RANKED_SUBSET" | "LEXICAL_FORCED_ONLY"
+                    | "MIXED_EMBED_AND_LEXICAL" => routing_codes::ISSUE_PRELLM_SEMANTIC_HIT,
+                    _ => routing_codes::ISSUE_PRELLM_POLICY_REWRITE,
                 };
                 tracing::info!(
                     category = routing_codes::CATEGORY_ROUTING,
                     issue,
-                    outcome = routing_codes::outcome_from_pre_llm_tuple(true, router_match_count),
+                    outcome = routing_codes::outcome_from_pre_llm_tuple(
+                        decision.tools_needed(),
+                        router_match_count
+                    ),
                     turn_seq,
-                    tools_needed = true,
+                    rule_id = decision.rule_id,
+                    offer_kind = decision.offer.kind_label(),
+                    tools_needed = decision.tools_needed(),
                     router_match_count,
-                    policy_reason = policy.reason,
                     raw_matched = ?raw_preview,
                     offered = ?names,
-                    "semantic tool match; tool mode (Phase-1 policy applied)"
+                    "pre-LLM routing decision"
                 );
-                (true, names)
+                decision
             }
             Err(e) => {
                 self.last_router_ms = router_started.elapsed().as_millis() as u64;
@@ -149,14 +155,16 @@ impl<E: LlmEngine> Orchestrator<E> {
                 tracing::warn!(
                     category = routing_codes::CATEGORY_ROUTING,
                     issue = routing_codes::ISSUE_PRELLM_MATCH_ERROR,
-                    outcome = routing_codes::outcome_from_pre_llm_tuple(true, 0),
+                    outcome = routing_codes::OUTCOME_TOOL_FALLBACK,
                     turn_seq,
+                    rule_id = "MATCH_ERROR",
+                    offer_kind = "full_roster",
                     tools_needed = true,
                     router_match_count = 0usize,
                     fcp_error = %e,
                     "pre-LLM match_tools failed; roster-only tool mode"
                 );
-                (true, Vec::new())
+                RoutingDecision::full_roster("MATCH_ERROR")
             }
         }
     }

--- a/src/orchestrator/core/pre_llm_routing.rs
+++ b/src/orchestrator/core/pre_llm_routing.rs
@@ -1,4 +1,7 @@
 use crate::engine::LlmEngine;
+use crate::orchestrator::routing::{
+    apply_routing_policy, RoutingPolicyKnobs,
+};
 use crate::orchestrator::tool_router::ToolRouter;
 use crate::presentation::SYSTEM_ALARM_PREFIX;
 use crate::telemetry::routing_codes;
@@ -9,13 +12,13 @@ use super::Orchestrator;
 impl<E: LlmEngine> Orchestrator<E> {
     /// Conversational vs tool mode, plus ordered router names for Tier 1 (Top-K).
     pub(super) async fn run_pre_llm_routing(&mut self) -> (bool, Vec<String>) {
-        let user_input = self.last_user_content();
+        let user_input = self.last_user_content().to_string();
         let turn_seq = self.turn_seq;
 
         if user_input.starts_with(SYSTEM_ALARM_PREFIX) {
             let alarm_payload = user_input
                 .strip_prefix(SYSTEM_ALARM_PREFIX)
-                .unwrap_or(user_input);
+                .unwrap_or(user_input.as_str());
             if alarm_payload.to_ascii_lowercase().contains("moltbook") {
                 tracing::info!(
                     category = routing_codes::CATEGORY_ROUTING,
@@ -42,7 +45,7 @@ impl<E: LlmEngine> Orchestrator<E> {
             }
         }
 
-        if ToolRouter::short_input_guard_conversational_only(user_input) {
+        if ToolRouter::short_input_guard_conversational_only(&user_input) {
             self.last_router_ms = 0;
             self.last_top_tool_match = None;
             tracing::info!(
@@ -57,23 +60,26 @@ impl<E: LlmEngine> Orchestrator<E> {
             return (false, Vec::new());
         }
 
-        let Some(router) = &self.tool_router else {
-            self.last_router_ms = 0;
-            self.last_top_tool_match = None;
-            tracing::warn!(
-                category = routing_codes::CATEGORY_ROUTING,
-                issue = routing_codes::ISSUE_PRELLM_ROUTER_UNAVAILABLE,
-                outcome = routing_codes::outcome_from_pre_llm_tuple(true, 0),
-                turn_seq,
-                tools_needed = true,
-                router_match_count = 0usize,
-                "no tool router; roster-only tool mode"
-            );
-            return (true, Vec::new());
+        let router_started = Instant::now();
+        let match_result = {
+            let Some(router) = self.tool_router.as_ref() else {
+                self.last_router_ms = 0;
+                self.last_top_tool_match = None;
+                tracing::warn!(
+                    category = routing_codes::CATEGORY_ROUTING,
+                    issue = routing_codes::ISSUE_PRELLM_ROUTER_UNAVAILABLE,
+                    outcome = routing_codes::outcome_from_pre_llm_tuple(true, 0),
+                    turn_seq,
+                    tools_needed = true,
+                    router_match_count = 0usize,
+                    "no tool router; roster-only tool mode"
+                );
+                return (true, Vec::new());
+            };
+            router.match_tools(&user_input).await
         };
 
-        let router_started = Instant::now();
-        match router.match_tools(user_input).await {
+        match match_result {
             Ok(matches) if matches.is_empty() => {
                 self.last_router_ms = router_started.elapsed().as_millis() as u64;
                 self.last_top_tool_match = None;
@@ -90,24 +96,50 @@ impl<E: LlmEngine> Orchestrator<E> {
             }
             Ok(matches) => {
                 self.last_router_ms = router_started.elapsed().as_millis() as u64;
-                self.last_top_tool_match = matches
-                    .first()
-                    .map(|(name, score)| format!("{name}({score:.3})"));
-                let matched_preview: Vec<String> = matches
+                let raw_preview: Vec<String> = matches
                     .iter()
                     .map(|(n, s)| format!("{}({:.3})", n, s))
                     .collect();
-                let names: Vec<String> = matches.into_iter().map(|(name, _)| name).collect();
+                let registered = self.gatekeeper.registered_tool_names();
+                let knobs = RoutingPolicyKnobs {
+                    single_hit_floor: self.config.tool_single_hit_floor,
+                    match_margin: self.config.tool_match_margin,
+                };
+                let recent = self.recent_successful_tools.clone();
+                let policy = apply_routing_policy(
+                    &user_input,
+                    &matches,
+                    &recent,
+                    &registered,
+                    knobs,
+                );
+                self.last_top_tool_match = policy
+                    .offered
+                    .first()
+                    .cloned()
+                    .or_else(|| matches.first().map(|(n, s)| format!("{n}({s:.3})")));
+                let names = policy.offered;
                 let router_match_count = names.len();
+                let issue = if policy.reason == "EMPTY_AFTER_POLICY" && !matches.is_empty() {
+                    routing_codes::ISSUE_PRELLM_POLICY_REWRITE
+                } else if policy.reason == "AGENDA_DIALOG_PAIRING"
+                    || policy.reason == "MARGIN_CLUSTER_OR_SUBSET"
+                {
+                    routing_codes::ISSUE_PRELLM_POLICY_REWRITE
+                } else {
+                    routing_codes::ISSUE_PRELLM_SEMANTIC_HIT
+                };
                 tracing::info!(
                     category = routing_codes::CATEGORY_ROUTING,
-                    issue = routing_codes::ISSUE_PRELLM_SEMANTIC_HIT,
+                    issue,
                     outcome = routing_codes::outcome_from_pre_llm_tuple(true, router_match_count),
                     turn_seq,
                     tools_needed = true,
                     router_match_count,
-                    matched = ?matched_preview,
-                    "semantic tool match; tool mode"
+                    policy_reason = policy.reason,
+                    raw_matched = ?raw_preview,
+                    offered = ?names,
+                    "semantic tool match; tool mode (Phase-1 policy applied)"
                 );
                 (true, names)
             }
@@ -126,6 +158,16 @@ impl<E: LlmEngine> Orchestrator<E> {
                 );
                 (true, Vec::new())
             }
+        }
+    }
+
+    /// Record a successful tool for dialog-continuation routing (session-scoped, capped).
+    pub(super) fn record_successful_tool(&mut self, tool_name: &str) {
+        const CAP: usize = 12;
+        self.recent_successful_tools.push(tool_name.to_string());
+        if self.recent_successful_tools.len() > CAP {
+            let drain = self.recent_successful_tools.len() - CAP;
+            self.recent_successful_tools.drain(0..drain);
         }
     }
 }

--- a/src/orchestrator/core/step.rs
+++ b/src/orchestrator/core/step.rs
@@ -312,6 +312,27 @@ impl<E: LlmEngine> Orchestrator<E> {
                 system_prompt.push_str("\n\n---\n\n");
                 system_prompt.push_str(&skill);
             }
+            // Soft-compel: URL in user text + web:fetch offered → prompt bias (Idle still allowed).
+            if tools_needed
+                && crate::orchestrator::routing::should_soft_compel_web_fetch(
+                    self.last_user_content(),
+                )
+            {
+                // Empty matched tools = full roster (fetch available). Named hits must include fetch.
+                let fetch_offered = pre_llm_matched_tools.is_empty()
+                    || pre_llm_matched_tools.iter().any(|n| n == "web:fetch");
+                if fetch_offered {
+                    system_prompt.push_str("\n\n---\n\n");
+                    system_prompt
+                        .push_str(crate::orchestrator::routing::URL_SOFT_COMPEL_HINT);
+                    tracing::info!(
+                        category = routing_codes::CATEGORY_ROUTING,
+                        issue = routing_codes::ISSUE_PRELLM_URL_SOFT_COMPEL,
+                        turn_seq = self.turn_seq,
+                        "URL soft-compel hint injected into system prompt"
+                    );
+                }
+            }
             Self::upsert_system_prompt(&mut self.chat_stack, system_prompt);
 
             if self.config.optimize_context_proactive_condensation {

--- a/src/orchestrator/core/step.rs
+++ b/src/orchestrator/core/step.rs
@@ -131,7 +131,9 @@ impl<E: LlmEngine> Orchestrator<E> {
         }
 
         // ── Pre-LLM semantic routing ─────────────────────────────────
-        let (mut tools_needed, pre_llm_matched_tools) = self.run_pre_llm_routing().await;
+        let routing = self.run_pre_llm_routing().await;
+        let mut tools_needed = routing.tools_needed();
+        let pre_llm_matched_tools = routing.matched_tool_names();
         let mut execution_ledger: HashMap<String, ToolIntentTicket> = HashMap::new();
         let mut schema_recovery_attempted: HashSet<String> = HashSet::new();
         let mut targeted_tools: HashSet<String> = HashSet::new();

--- a/src/orchestrator/core/step.rs
+++ b/src/orchestrator/core/step.rs
@@ -27,6 +27,41 @@ pub(crate) fn trailing_json_recovery_triggered(config: &AppConfig, content: &str
     !config.is_llamacpp() && trailing_content_after_valid_llm_json(content)
 }
 
+/// Scorecard: URL in user text, `web:fetch` offered, model did not call it this hop.
+fn maybe_log_url_skip_fetch(
+    url_fetch_offered: bool,
+    soft_compel_injected: bool,
+    turn_seq: u64,
+    transition: &StateTransition,
+) {
+    if !url_fetch_offered {
+        return;
+    }
+    // Recover / fatal / reflection hops are not Idle skip-fetch events.
+    let (called_fetch, tool_count, outcome) = match transition {
+        StateTransition::ExecuteTools(tools) => {
+            let called = tools.iter().any(|t| t.name == "web:fetch");
+            (called, tools.len(), "execute_tools")
+        }
+        StateTransition::Halt => (false, 0, "halt_idle"),
+        StateTransition::ShiftToReflection => (false, 0, "reflect"),
+        StateTransition::Recover { .. } => return,
+        StateTransition::Fatal(_) | StateTransition::Continue => return,
+    };
+    if called_fetch {
+        return;
+    }
+    tracing::info!(
+        category = routing_codes::CATEGORY_ROUTING,
+        issue = routing_codes::ISSUE_PRELLM_URL_SKIP_FETCH,
+        turn_seq,
+        soft_compel_injected,
+        tool_count,
+        outcome,
+        "URL present and web:fetch offered; model did not call web:fetch this hop"
+    );
+}
+
 impl<E: LlmEngine> Orchestrator<E> {
     /// The main cognitive loop.
     ///
@@ -144,6 +179,9 @@ impl<E: LlmEngine> Orchestrator<E> {
 
         // ── Tool-enabled loop (full schemas) ─────────────────────────
         loop {
+            // URL scorecard (Phase 3): set each hop when fetch is offered with a URL in user text.
+            let mut url_fetch_offered_this_hop = false;
+            let mut url_soft_compel_injected = false;
             // 1. Bailout Checks
             if self.recovery_count >= self.max_recovery_attempts {
                 tracing::warn!(
@@ -314,25 +352,28 @@ impl<E: LlmEngine> Orchestrator<E> {
                 system_prompt.push_str("\n\n---\n\n");
                 system_prompt.push_str(&skill);
             }
-            // Soft-compel: URL in user text + web:fetch offered → prompt bias (Idle still allowed).
-            if tools_needed
-                && crate::orchestrator::routing::should_soft_compel_web_fetch(
-                    self.last_user_content(),
-                )
-            {
-                // Empty matched tools = full roster (fetch available). Named hits must include fetch.
+            // URL scorecard + soft-compel: fetch offered with URL → may inject prompt bias.
+            // Opinion-only phrasing skips the hint but still counts toward skip-fetch telemetry.
+            if tools_needed {
+                let user_line = self.last_user_content();
                 let fetch_offered = pre_llm_matched_tools.is_empty()
                     || pre_llm_matched_tools.iter().any(|n| n == "web:fetch");
-                if fetch_offered {
-                    system_prompt.push_str("\n\n---\n\n");
-                    system_prompt
-                        .push_str(crate::orchestrator::routing::URL_SOFT_COMPEL_HINT);
-                    tracing::info!(
-                        category = routing_codes::CATEGORY_ROUTING,
-                        issue = routing_codes::ISSUE_PRELLM_URL_SOFT_COMPEL,
-                        turn_seq = self.turn_seq,
-                        "URL soft-compel hint injected into system prompt"
-                    );
+                if fetch_offered
+                    && crate::orchestrator::routing::user_text_has_url(user_line)
+                {
+                    url_fetch_offered_this_hop = true;
+                    if crate::orchestrator::routing::should_soft_compel_web_fetch(user_line) {
+                        system_prompt.push_str("\n\n---\n\n");
+                        system_prompt
+                            .push_str(crate::orchestrator::routing::URL_SOFT_COMPEL_HINT);
+                        url_soft_compel_injected = true;
+                        tracing::info!(
+                            category = routing_codes::CATEGORY_ROUTING,
+                            issue = routing_codes::ISSUE_PRELLM_URL_SOFT_COMPEL,
+                            turn_seq = self.turn_seq,
+                            "URL soft-compel hint injected into system prompt"
+                        );
+                    }
                 }
             }
             Self::upsert_system_prompt(&mut self.chat_stack, system_prompt);
@@ -595,6 +636,12 @@ impl<E: LlmEngine> Orchestrator<E> {
                     .clamp_transition_for_tool_round_cap_recovery(transition, &response.content)
                     .await;
             }
+            maybe_log_url_skip_fetch(
+                url_fetch_offered_this_hop,
+                url_soft_compel_injected,
+                turn_seq,
+                &transition,
+            );
             match transition {
                 StateTransition::ExecuteTools(tools) => {
                     let decision = self

--- a/src/orchestrator/core/tool_dispatch.rs
+++ b/src/orchestrator/core/tool_dispatch.rs
@@ -268,6 +268,7 @@ impl<E: LlmEngine> Orchestrator<E> {
                     }
                     self.tool_rounds += 1;
                     self.recovery_count = 0;
+                    self.record_successful_tool(&tool_name);
                     tracing::info!(
                         tool = %tool_name,
                         intent_id = %intent_id,
@@ -568,6 +569,28 @@ impl<E: LlmEngine> Orchestrator<E> {
 
         if targeted_recovery_requested {
             self.force_full_tool_schemas_in_llm_view = true;
+            let registered = self.gatekeeper.registered_tool_names();
+            let allowed: HashSet<String> = self
+                .gatekeeper
+                .get_allowed_tools(&AgentState::Chat)
+                .into_iter()
+                .filter_map(|t| {
+                    t.get("function")
+                        .and_then(|f| f.get("name"))
+                        .and_then(|n| n.as_str())
+                        .map(|s| s.to_string())
+                })
+                .collect();
+            let expanded = crate::orchestrator::routing::expand_names_to_domain_clusters(
+                targeted_tools.iter().cloned(),
+                &registered,
+            );
+            for name in expanded {
+                if allowed.contains(&name) {
+                    targeted_tools.insert(name);
+                }
+            }
+            ensure_web_find_paired_with_fetch_tools(targeted_tools, &allowed);
             let selected = targeted_tools.iter().cloned().collect::<Vec<_>>();
             let msg = if self.config.is_llamacpp() {
                 let mut blocks: Vec<String> = Vec::new();
@@ -595,7 +618,7 @@ impl<E: LlmEngine> Orchestrator<E> {
                     selected
                 )
             };
-            tracing::info!(targeted_tools = ?selected, "Triggering targeted schema-fault recovery retry");
+            tracing::info!(targeted_tools = ?selected, "Triggering targeted schema-fault recovery retry (domain-cluster widened)");
             return Ok(ToolBatchDecision::RetryWithTargetedSchema { message: msg });
         }
 
@@ -618,12 +641,34 @@ impl<E: LlmEngine> Orchestrator<E> {
                         .map(|s| s.to_string())
                 })
                 .collect();
+            // Widen failed tools to their domain clusters so recovery is not locked onto
+            // the single wrong tool (e.g. doc:ingest → all doc:* + dialog seeds).
+            let registered = self.gatekeeper.registered_tool_names();
+            let expanded = crate::orchestrator::routing::expand_names_to_domain_clusters(
+                targeted_tools.iter().cloned(),
+                &registered,
+            );
+            for name in expanded {
+                if allowed.contains(&name) {
+                    targeted_tools.insert(name);
+                }
+            }
+            for recent in &self.recent_successful_tools {
+                if let Some(domain) = crate::orchestrator::routing::tool_domain(recent) {
+                    for name in crate::orchestrator::routing::cluster_members(domain, &registered)
+                    {
+                        if allowed.contains(&name) {
+                            targeted_tools.insert(name);
+                        }
+                    }
+                }
+            }
             ensure_web_find_paired_with_fetch_tools(targeted_tools, &allowed);
             if !targeted_tools.is_empty() {
                 self.force_full_tool_schemas_in_llm_view = true;
                 tracing::info!(
                     targeted_tools = ?targeted_tools,
-                    "Recoverable tool failure: targeted full schemas for retry"
+                    "Recoverable tool failure: targeted full schemas for retry (domain-cluster widened)"
                 );
             }
             let msg = recover_override_message_for_tool_failure(&reason);

--- a/src/orchestrator/core/turn_entry.rs
+++ b/src/orchestrator/core/turn_entry.rs
@@ -236,6 +236,16 @@ impl<E: LlmEngine> Orchestrator<E> {
         for name in candidates {
             targeted_tools.insert(name);
         }
+        let registered = self.gatekeeper.registered_tool_names();
+        let expanded = crate::orchestrator::routing::expand_names_to_domain_clusters(
+            targeted_tools.iter().cloned(),
+            &registered,
+        );
+        for name in expanded {
+            if allowed.contains(&name) {
+                targeted_tools.insert(name);
+            }
+        }
         crate::orchestrator::llm_support::post_tool_guidance::ensure_web_find_paired_with_fetch_tools(
             targeted_tools,
             &allowed,
@@ -247,7 +257,7 @@ impl<E: LlmEngine> Orchestrator<E> {
         self.force_full_tool_schemas_in_llm_view = true;
         tracing::info!(
             targeted_tools = ?targeted_tools,
-            "Recover pass armed with targeted full tool schemas"
+            "Recover pass armed with targeted full tool schemas (domain-cluster widened)"
         );
     }
 

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -4,6 +4,7 @@ pub mod core;
 pub mod heartbeat;
 pub mod llm_support;
 pub mod r#loop;
+pub mod routing;
 pub mod state;
 pub mod tool_router;
 

--- a/src/orchestrator/routing/clusters.rs
+++ b/src/orchestrator/routing/clusters.rs
@@ -1,0 +1,152 @@
+//! Domain clusters for Phase-1 tool-routing policy.
+//!
+//! When the semantic router is unsure (weak lone hit, near-tie across families),
+//! we widen the offer to a prefix cluster instead of locking GBNF onto one tool.
+
+/// Domain key for a tool name (`"agenda:list"` → `"agenda"`).
+#[must_use]
+pub fn tool_domain(name: &str) -> Option<&str> {
+    let (prefix, rest) = name.split_once(':')?;
+    if prefix.is_empty() || rest.is_empty() {
+        return None;
+    }
+    Some(prefix)
+}
+
+/// Affinity bucket for margin multi-domain union.
+///
+/// Only domains that share a bucket are cluster-unioned on a near-tie. Unrelated
+/// mush (e.g. `moltbook` + `web` + `db` + `doc`) stays a ranked subset — no A–Z dump.
+#[must_use]
+pub fn affinity_group(domain: &str) -> Option<&'static str> {
+    match domain {
+        "agenda" | "clock" | "calendar" => Some("time"),
+        "web" | "news" | "wiki" => Some("web"),
+        "doc" | "vault" | "memory" | "media" => Some("knowledge"),
+        "mail" => Some("mail"),
+        "weather" => Some("weather"),
+        "moltbook" => Some("moltbook"),
+        "db" => Some("db"),
+        "vision" => Some("vision"),
+        "system" | "skills" => Some("system"),
+        _ => None,
+    }
+}
+
+/// True when two domains may be widened together on a near-tie.
+#[must_use]
+pub fn domains_share_affinity(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    match (affinity_group(a), affinity_group(b)) {
+        (Some(x), Some(y)) => x == y,
+        _ => false,
+    }
+}
+
+/// Registered tools whose names start with `{domain}:`.
+#[must_use]
+pub fn cluster_members(domain: &str, registered: &[String]) -> Vec<String> {
+    let needle = format!("{domain}:");
+    let mut out: Vec<String> = registered
+        .iter()
+        .filter(|n| n.starts_with(&needle))
+        .cloned()
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Union of cluster members for every distinct domain in `tool_names`.
+///
+/// Order is alphabetical for a stable set; callers that feed slim/GBNF should
+/// re-rank by cosine (see [`super::policy`]).
+#[must_use]
+pub fn union_clusters_for_tools(tool_names: &[String], registered: &[String]) -> Vec<String> {
+    let mut domains: Vec<&str> = tool_names
+        .iter()
+        .filter_map(|n| tool_domain(n))
+        .collect();
+    domains.sort_unstable();
+    domains.dedup();
+
+    let mut out = Vec::new();
+    for domain in domains {
+        out.extend(cluster_members(domain, registered));
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Expand a set of tool names to include every registered sibling in the same domain(s).
+pub fn expand_names_to_domain_clusters(
+    names: impl IntoIterator<Item = String>,
+    registered: &[String],
+) -> Vec<String> {
+    let seed: Vec<String> = names.into_iter().collect();
+    if seed.is_empty() {
+        return Vec::new();
+    }
+    union_clusters_for_tools(&seed, registered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_registry() -> Vec<String> {
+        vec![
+            "agenda:list".into(),
+            "agenda:remove".into(),
+            "agenda:complete".into(),
+            "agenda:remind_at".into(),
+            "clock:now".into(),
+            "clock:alarm".into(),
+            "clock:timer".into(),
+            "doc:ingest".into(),
+            "doc:query".into(),
+            "web:fetch".into(),
+            "web:find".into(),
+            "web:search".into(),
+        ]
+    }
+
+    #[test]
+    fn tool_domain_parses_prefix() {
+        assert_eq!(tool_domain("agenda:list"), Some("agenda"));
+        assert_eq!(tool_domain("clock:alarm"), Some("clock"));
+        assert_eq!(tool_domain("nope"), None);
+        assert_eq!(tool_domain(":bad"), None);
+    }
+
+    #[test]
+    fn cluster_members_filters_prefix() {
+        let reg = sample_registry();
+        let agenda = cluster_members("agenda", &reg);
+        assert!(agenda.iter().all(|n| n.starts_with("agenda:")));
+        assert!(agenda.contains(&"agenda:remove".to_string()));
+        assert!(!agenda.iter().any(|n| n.starts_with("clock:")));
+    }
+
+    #[test]
+    fn union_clusters_merges_clock_and_agenda() {
+        let reg = sample_registry();
+        let seeds = vec!["clock:alarm".into(), "agenda:remind_at".into()];
+        let union = union_clusters_for_tools(&seeds, &reg);
+        assert!(union.contains(&"clock:timer".to_string()));
+        assert!(union.contains(&"agenda:list".to_string()));
+        assert!(!union.contains(&"doc:ingest".to_string()));
+    }
+
+    #[test]
+    fn affinity_groups_time_but_not_db_web() {
+        assert!(domains_share_affinity("clock", "agenda"));
+        assert!(domains_share_affinity("web", "news"));
+        assert!(!domains_share_affinity("moltbook", "web"));
+        assert!(!domains_share_affinity("db", "web"));
+        assert_eq!(affinity_group("clock"), Some("time"));
+    }
+}

--- a/src/orchestrator/routing/decision.rs
+++ b/src/orchestrator/routing/decision.rs
@@ -1,0 +1,150 @@
+//! Explicit pre-LLM routing offer (Phase 2).
+//!
+//! Cosine hits and lexical guards remain signals; this type is the **decision**
+//! that drives slim prompt assembly and GBNF subset selection.
+
+/// What the orchestrator should offer the model this turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoutingOffer {
+    /// No tool schemas; conversational envelope only.
+    Conversational,
+    /// Named tools (cosine-ranked). May be a tight hit list or an expanded set.
+    Subset(Vec<String>),
+    /// Affinity / dialog cluster expansion. `domains` is for telemetry; `tools` is the offer.
+    DomainCluster {
+        domains: Vec<&'static str>,
+        tools: Vec<String>,
+    },
+    /// Tool mode with empty name list → full allowed roster (existing slim/GBNF convention).
+    FullRoster,
+}
+
+impl RoutingOffer {
+    #[must_use]
+    pub fn tools_needed(&self) -> bool {
+        !matches!(self, Self::Conversational)
+    }
+
+    /// Names for slim map / GBNF. Empty means full roster when [`Self::tools_needed`].
+    #[must_use]
+    pub fn matched_tool_names(&self) -> Vec<String> {
+        match self {
+            Self::Conversational | Self::FullRoster => Vec::new(),
+            Self::Subset(tools) => tools.clone(),
+            Self::DomainCluster { tools, .. } => tools.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn kind_label(&self) -> &'static str {
+        match self {
+            Self::Conversational => "conversational",
+            Self::Subset(_) => "subset",
+            Self::DomainCluster { .. } => "domain_cluster",
+            Self::FullRoster => "full_roster",
+        }
+    }
+}
+
+/// Full pre-LLM routing outcome: offer + which rule produced it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutingDecision {
+    pub offer: RoutingOffer,
+    /// Stable rule id for logs (`AGENDA_DIALOG_PAIRING`, `SHORT_INPUT`, …).
+    pub rule_id: &'static str,
+}
+
+impl RoutingDecision {
+    #[must_use]
+    pub fn conversational(rule_id: &'static str) -> Self {
+        Self {
+            offer: RoutingOffer::Conversational,
+            rule_id,
+        }
+    }
+
+    #[must_use]
+    pub fn full_roster(rule_id: &'static str) -> Self {
+        Self {
+            offer: RoutingOffer::FullRoster,
+            rule_id,
+        }
+    }
+
+    #[must_use]
+    pub fn subset(rule_id: &'static str, tools: Vec<String>) -> Self {
+        Self {
+            offer: RoutingOffer::Subset(tools),
+            rule_id,
+        }
+    }
+
+    #[must_use]
+    pub fn domain_cluster(
+        rule_id: &'static str,
+        domains: Vec<&'static str>,
+        tools: Vec<String>,
+    ) -> Self {
+        Self {
+            offer: RoutingOffer::DomainCluster { domains, tools },
+            rule_id,
+        }
+    }
+
+    #[must_use]
+    pub fn tools_needed(&self) -> bool {
+        self.offer.tools_needed()
+    }
+
+    #[must_use]
+    pub fn matched_tool_names(&self) -> Vec<String> {
+        self.offer.matched_tool_names()
+    }
+}
+
+/// When a lone weak embed hit is demoted, how to fall through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UnsureFallback {
+    /// Empty matched names → full allowed roster (historic default).
+    #[default]
+    FullRoster,
+    /// Expand the demoted tool's domain cluster instead of opening the full roster.
+    DomainCluster,
+}
+
+impl UnsureFallback {
+    #[must_use]
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "domain_cluster" | "cluster" => Self::DomainCluster,
+            _ => Self::FullRoster,
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FullRoster => "full_roster",
+            Self::DomainCluster => "domain_cluster",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_roster_and_conversational_expose_empty_names() {
+        assert!(RoutingOffer::FullRoster.tools_needed());
+        assert!(RoutingOffer::FullRoster.matched_tool_names().is_empty());
+        assert!(!RoutingOffer::Conversational.tools_needed());
+    }
+
+    #[test]
+    fn unsure_fallback_parse() {
+        assert_eq!(UnsureFallback::parse("domain_cluster"), UnsureFallback::DomainCluster);
+        assert_eq!(UnsureFallback::parse("full_roster"), UnsureFallback::FullRoster);
+        assert_eq!(UnsureFallback::parse("nope"), UnsureFallback::FullRoster);
+    }
+}

--- a/src/orchestrator/routing/dialog.rs
+++ b/src/orchestrator/routing/dialog.rs
@@ -1,0 +1,295 @@
+//! Dialog-continuation pairing: after a successful tool in a domain, map
+//! follow-up phrasing onto that domain's cluster (and suppress weak cross-domain lock-in).
+
+use super::clusters::expand_names_to_domain_clusters;
+use super::decision::RoutingDecision;
+use super::signals::RoutingSignals;
+
+const FORCED_HIT_FLOOR: f32 = 0.99;
+
+/// Ordered dialog-pairing rules. First match wins (agenda before mail/calendar/doc).
+#[must_use]
+pub fn try_dialog_pairing(
+    signals: &RoutingSignals,
+    registered: &[String],
+) -> Option<RoutingDecision> {
+    if let Some(d) = rule_agenda(signals, registered) {
+        return Some(d);
+    }
+    if let Some(d) = rule_mail(signals, registered) {
+        return Some(d);
+    }
+    if let Some(d) = rule_calendar(signals, registered) {
+        return Some(d);
+    }
+    rule_doc(signals, registered)
+}
+
+fn rule_agenda(signals: &RoutingSignals, registered: &[String]) -> Option<RoutingDecision> {
+    if !signals.recent_had_agenda || !signals.agenda_continuation || signals.doc_ingest_cues {
+        return None;
+    }
+    // Prefer agenda over mail/calendar when recent agenda exists and cues match.
+    let suppressed_doc = signals
+        .embed_hits
+        .iter()
+        .any(|(n, s)| n.starts_with("doc:") && *s < FORCED_HIT_FLOOR);
+
+    let offered = prefer_front(
+        expand_names_to_domain_clusters(
+            ["agenda:remove", "agenda:complete", "agenda:list"]
+                .into_iter()
+                .map(str::to_string),
+            registered,
+        ),
+        &["agenda:remove", "agenda:complete", "agenda:list"],
+        registered,
+    );
+
+    tracing::info!(
+        suppressed_doc_hits = suppressed_doc,
+        offered = ?offered,
+        event = "routing.policy.dialog_pairing",
+        domain = "agenda",
+        "Agenda dialog continuation; offering agenda cluster"
+    );
+
+    Some(RoutingDecision::domain_cluster(
+        "AGENDA_DIALOG_PAIRING",
+        vec!["agenda"],
+        offered,
+    ))
+}
+
+fn rule_mail(signals: &RoutingSignals, registered: &[String]) -> Option<RoutingDecision> {
+    if !signals.recent_had_mail || signals.doc_ingest_cues {
+        return None;
+    }
+    // Destructive bare remove/delete without mail nouns → leave to agenda or ranked path.
+    let preferred: &[&str] = if signals.mail_delete_continuation {
+        &["mail:delete", "mail:check", "mail:digest"]
+    } else if signals.mail_move_continuation {
+        &["mail:move", "mail:check", "mail:read"]
+    } else if signals.mail_reply_continuation {
+        &["mail:write", "mail:read", "mail:check"]
+    } else if signals.mail_read_continuation {
+        &["mail:read", "mail:check", "mail:digest"]
+    } else {
+        return None;
+    };
+
+    let offered = prefer_front(
+        expand_names_to_domain_clusters(
+            preferred.iter().map(|s| (*s).to_string()),
+            registered,
+        ),
+        preferred,
+        registered,
+    );
+
+    tracing::info!(
+        offered = ?offered,
+        event = "routing.policy.dialog_pairing",
+        domain = "mail",
+        "Mail dialog continuation; offering mail cluster"
+    );
+
+    Some(RoutingDecision::domain_cluster(
+        "MAIL_DIALOG_PAIRING",
+        vec!["mail"],
+        offered,
+    ))
+}
+
+fn rule_calendar(signals: &RoutingSignals, registered: &[String]) -> Option<RoutingDecision> {
+    if !signals.recent_had_calendar || signals.doc_ingest_cues {
+        return None;
+    }
+    let preferred: &[&str] = if signals.calendar_delete_continuation {
+        &["calendar:delete", "calendar:list", "calendar:get"]
+    } else if signals.calendar_update_continuation {
+        &["calendar:update", "calendar:get", "calendar:list"]
+    } else if signals.calendar_get_continuation {
+        &["calendar:get", "calendar:list"]
+    } else {
+        return None;
+    };
+
+    let offered = prefer_front(
+        expand_names_to_domain_clusters(
+            preferred.iter().map(|s| (*s).to_string()),
+            registered,
+        ),
+        preferred,
+        registered,
+    );
+
+    tracing::info!(
+        offered = ?offered,
+        event = "routing.policy.dialog_pairing",
+        domain = "calendar",
+        "Calendar dialog continuation; offering calendar cluster only (not full time affinity)"
+    );
+
+    Some(RoutingDecision::domain_cluster(
+        "CALENDAR_DIALOG_PAIRING",
+        vec!["calendar"],
+        offered,
+    ))
+}
+
+fn rule_doc(signals: &RoutingSignals, registered: &[String]) -> Option<RoutingDecision> {
+    // Gated: require document-anchored delete language — bare "remove it" stays agenda/mail.
+    if !signals.recent_had_doc_catalog || !signals.doc_delete_continuation {
+        return None;
+    }
+    if signals.agenda_continuation && signals.recent_had_agenda {
+        return None;
+    }
+
+    let preferred = ["doc:delete", "doc:list", "doc:query"];
+    let offered = prefer_front(
+        expand_names_to_domain_clusters(
+            preferred.iter().map(|s| (*s).to_string()),
+            registered,
+        ),
+        &preferred,
+        registered,
+    );
+
+    tracing::info!(
+        offered = ?offered,
+        event = "routing.policy.dialog_pairing",
+        domain = "doc",
+        "Doc dialog continuation (document-anchored); offering doc cluster without ingest bias"
+    );
+
+    Some(RoutingDecision::domain_cluster(
+        "DOC_DIALOG_PAIRING",
+        vec!["doc"],
+        offered,
+    ))
+}
+
+fn prefer_front(
+    mut offered: Vec<String>,
+    preferred: &[&str],
+    registered: &[String],
+) -> Vec<String> {
+    let mut front = Vec::new();
+    for name in preferred {
+        if let Some(pos) = offered.iter().position(|n| n == *name) {
+            front.push(offered.remove(pos));
+        } else if registered.iter().any(|n| n == *name) {
+            front.push((*name).to_string());
+        }
+    }
+    front.append(&mut offered);
+    front
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestrator::routing::decision::RoutingOffer;
+    use crate::orchestrator::routing::signals::RoutingSignals;
+
+    fn reg() -> Vec<String> {
+        vec![
+            "agenda:list".into(),
+            "agenda:remove".into(),
+            "agenda:complete".into(),
+            "agenda:push".into(),
+            "mail:check".into(),
+            "mail:read".into(),
+            "mail:delete".into(),
+            "mail:move".into(),
+            "mail:write".into(),
+            "mail:digest".into(),
+            "calendar:list".into(),
+            "calendar:get".into(),
+            "calendar:delete".into(),
+            "calendar:update".into(),
+            "doc:list".into(),
+            "doc:delete".into(),
+            "doc:query".into(),
+            "doc:ingest".into(),
+            "doc:read".into(),
+        ]
+    }
+
+    fn signals(
+        text: &str,
+        recent: &[&str],
+        hits: Vec<(String, f32)>,
+    ) -> RoutingSignals {
+        RoutingSignals::from_turn(
+            text,
+            hits,
+            &recent.iter().map(|s| (*s).to_string()).collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn mail_delete_after_check() {
+        let s = signals(
+            "please delete that email from my inbox",
+            &["mail:check"],
+            vec![("doc:delete".into(), 0.52)],
+        );
+        let d = try_dialog_pairing(&s, &reg()).expect("mail pairing");
+        assert_eq!(d.rule_id, "MAIL_DIALOG_PAIRING");
+        assert_eq!(d.matched_tool_names()[0], "mail:delete");
+    }
+
+    #[test]
+    fn calendar_cancel_after_list() {
+        let s = signals(
+            "please cancel that meeting on my calendar",
+            &["calendar:list"],
+            vec![("agenda:remove".into(), 0.55)],
+        );
+        let d = try_dialog_pairing(&s, &reg()).expect("calendar pairing");
+        assert_eq!(d.rule_id, "CALENDAR_DIALOG_PAIRING");
+        assert_eq!(d.matched_tool_names()[0], "calendar:delete");
+        match &d.offer {
+            RoutingOffer::DomainCluster { domains, .. } => assert_eq!(domains.as_slice(), ["calendar"]),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn bare_remove_after_doc_list_does_not_pair_doc() {
+        let s = signals(
+            "please remove it",
+            &["doc:list"],
+            vec![("doc:delete".into(), 0.51)],
+        );
+        assert!(try_dialog_pairing(&s, &reg()).is_none());
+    }
+
+    #[test]
+    fn doc_anchored_delete_after_list() {
+        let s = signals(
+            "please delete that document from the ingested store",
+            &["doc:list"],
+            vec![("agenda:remove".into(), 0.52)],
+        );
+        let d = try_dialog_pairing(&s, &reg()).expect("doc pairing");
+        assert_eq!(d.rule_id, "DOC_DIALOG_PAIRING");
+        assert_eq!(d.matched_tool_names()[0], "doc:delete");
+        // Prefer delete/list/query; ingest may remain in cluster but not first.
+        assert_ne!(d.matched_tool_names()[0], "doc:ingest");
+    }
+
+    #[test]
+    fn agenda_beats_mail_when_both_recent() {
+        let s = signals(
+            "please remove that from my agenda",
+            &["mail:check", "agenda:list"],
+            vec![("mail:delete".into(), 0.6)],
+        );
+        let d = try_dialog_pairing(&s, &reg()).expect("agenda first");
+        assert_eq!(d.rule_id, "AGENDA_DIALOG_PAIRING");
+    }
+}

--- a/src/orchestrator/routing/mod.rs
+++ b/src/orchestrator/routing/mod.rs
@@ -1,16 +1,25 @@
-//! Pre-LLM tool-offer policy (Phase 1).
+//! Pre-LLM tool-offer policy: signals → decision → slim/GBNF offer set.
 //!
-//! Cosine hits remain the primary signal; this module demotes weak lock-in,
-//! widens near-ties to domain clusters, and pairs agenda dialog continuations.
+//! Phase 1 shipped demotion / affinity unions / dialog pairing.
+//! Phase 2 formalizes [`RoutingOffer`] and named rule ids without changing
+//! the orchestrator's slim/GBNF wiring conventions.
 
 pub mod clusters;
+pub mod decision;
+pub mod overlays;
 pub mod policy;
+pub mod signals;
 
 pub use clusters::{
     affinity_group, cluster_members, domains_share_affinity, expand_names_to_domain_clusters,
     tool_domain, union_clusters_for_tools,
 };
+pub use decision::{RoutingDecision, RoutingOffer, UnsureFallback};
+pub use overlays::apply_offer_overlays;
 pub use policy::{
-    apply_routing_policy, should_soft_compel_web_fetch, RoutingPolicyKnobs, RoutingPolicyResult,
+    apply_routing_policy, decide, should_soft_compel_web_fetch, RoutingPolicyKnobs,
     URL_SOFT_COMPEL_HINT,
+};
+pub use signals::{
+    has_agenda_continuation_intent, has_doc_ingest_cues, RoutingSignals,
 };

--- a/src/orchestrator/routing/mod.rs
+++ b/src/orchestrator/routing/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod clusters;
 pub mod decision;
+pub mod dialog;
 pub mod overlays;
 pub mod policy;
 pub mod signals;
@@ -21,5 +22,6 @@ pub use policy::{
     URL_SOFT_COMPEL_HINT,
 };
 pub use signals::{
-    has_agenda_continuation_intent, has_doc_ingest_cues, RoutingSignals,
+    has_agenda_continuation_intent, has_doc_delete_continuation, has_doc_ingest_cues,
+    RoutingSignals,
 };

--- a/src/orchestrator/routing/mod.rs
+++ b/src/orchestrator/routing/mod.rs
@@ -18,8 +18,8 @@ pub use clusters::{
 pub use decision::{RoutingDecision, RoutingOffer, UnsureFallback};
 pub use overlays::apply_offer_overlays;
 pub use policy::{
-    apply_routing_policy, decide, should_soft_compel_web_fetch, RoutingPolicyKnobs,
-    URL_SOFT_COMPEL_HINT,
+    apply_routing_policy, decide, should_soft_compel_web_fetch, user_text_has_url,
+    RoutingPolicyKnobs, URL_SOFT_COMPEL_HINT,
 };
 pub use signals::{
     has_agenda_continuation_intent, has_doc_delete_continuation, has_doc_ingest_cues,

--- a/src/orchestrator/routing/mod.rs
+++ b/src/orchestrator/routing/mod.rs
@@ -1,0 +1,16 @@
+//! Pre-LLM tool-offer policy (Phase 1).
+//!
+//! Cosine hits remain the primary signal; this module demotes weak lock-in,
+//! widens near-ties to domain clusters, and pairs agenda dialog continuations.
+
+pub mod clusters;
+pub mod policy;
+
+pub use clusters::{
+    affinity_group, cluster_members, domains_share_affinity, expand_names_to_domain_clusters,
+    tool_domain, union_clusters_for_tools,
+};
+pub use policy::{
+    apply_routing_policy, should_soft_compel_web_fetch, RoutingPolicyKnobs, RoutingPolicyResult,
+    URL_SOFT_COMPEL_HINT,
+};

--- a/src/orchestrator/routing/overlays.rs
+++ b/src/orchestrator/routing/overlays.rs
@@ -1,0 +1,57 @@
+//! Slim-offer overlays shared by prompt assembly and GBNF subset selection.
+//!
+//! Single source of truth for: offer cap, Moltbook latch, `web:find` pairing,
+//! and `doc:read` → `vault:write`.
+
+use crate::orchestrator::state::AgentState;
+use crate::tools::Gatekeeper;
+
+/// Build the final offered-tool list for slim phrase map + subset grammar.
+#[must_use]
+pub fn apply_offer_overlays(
+    pre_llm_matched_tools: &[String],
+    tool_map_offer_cap: usize,
+    moltbook_overlay_latched: bool,
+    gatekeeper: &Gatekeeper,
+    state: &AgentState,
+) -> Vec<String> {
+    let mut offered: Vec<String> = if pre_llm_matched_tools.is_empty() {
+        vec![]
+    } else if tool_map_offer_cap == 0 {
+        pre_llm_matched_tools.to_vec()
+    } else {
+        pre_llm_matched_tools
+            .iter()
+            .take(tool_map_offer_cap)
+            .cloned()
+            .collect()
+    };
+
+    if moltbook_overlay_latched && !offered.is_empty() {
+        for name in gatekeeper.allowed_tool_names_with_prefix(state, "moltbook:") {
+            if !offered.contains(&name) {
+                offered.push(name);
+            }
+        }
+    }
+
+    let needs_web_find = offered.iter().any(|n| n == "web:fetch" || n == "web:search");
+    if needs_web_find {
+        let find_allowed = gatekeeper
+            .allowed_tool_names_with_prefix(state, "web:")
+            .into_iter()
+            .any(|n| n == "web:find");
+        if find_allowed && !offered.iter().any(|n| n == "web:find") {
+            offered.push("web:find".to_string());
+        }
+    }
+
+    if offered.iter().any(|n| n == "doc:read")
+        && !offered.iter().any(|n| n == "vault:write")
+        && Gatekeeper::state_allows_tool(state, "vault:write")
+    {
+        offered.push("vault:write".to_string());
+    }
+
+    offered
+}

--- a/src/orchestrator/routing/policy.rs
+++ b/src/orchestrator/routing/policy.rs
@@ -502,8 +502,25 @@ mod tests {
         assert!(names.contains(&"clock:timer".to_string()));
         assert!(names.contains(&"agenda:list".to_string()));
         assert!(!names.contains(&"doc:ingest".to_string()));
+        // Seed hit leads; unscored clock:* siblings inherit ~top and may rank before agenda.
         assert_eq!(names[0], "clock:alarm");
-        assert_eq!(names[1], "agenda:remind_at");
+        let agenda_pos = names
+            .iter()
+            .position(|n| n == "agenda:remind_at")
+            .expect("agenda:remind_at in affinity union");
+        assert!(
+            agenda_pos > 0,
+            "agenda seed should follow clock:alarm, got {names:?}"
+        );
+        // All clock:* from the union should still beat the agenda seed score (0.59).
+        for (i, n) in names.iter().enumerate() {
+            if n.starts_with("clock:") {
+                assert!(
+                    i < agenda_pos,
+                    "clock sibling {n} should rank before agenda:remind_at, got {names:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/orchestrator/routing/policy.rs
+++ b/src/orchestrator/routing/policy.rs
@@ -331,18 +331,29 @@ pub fn rerank_offered_by_cosine(offered: &[String], hits: &[(String, f32)]) -> V
     ranked
 }
 
+/// True when the user message looks like it contains a URL / host.
+#[must_use]
+pub fn user_text_has_url(user_text: &str) -> bool {
+    let lower = user_text.to_ascii_lowercase();
+    lower.contains("http://") || lower.contains("https://") || lower.contains("www.")
+}
+
 /// Prefer calling `web:fetch` this turn unless the user clearly wants opinion-only chatter.
+///
+/// Opinion-only (URL present, no fetch verbs): "do you know", "have you heard",
+/// "what do you think", prior-knowledge phrasing — Idle with empty `tool_calls` is allowed
+/// and we skip injecting [`URL_SOFT_COMPEL_HINT`]. Lexical URL inject may still offer fetch.
 #[must_use]
 pub fn should_soft_compel_web_fetch(user_text: &str) -> bool {
-    let lower = user_text.to_ascii_lowercase();
-    let has_url = lower.contains("http://")
-        || lower.contains("https://")
-        || lower.contains("www.");
-    if !has_url {
+    if !user_text_has_url(user_text) {
         return false;
     }
+    let lower = user_text.to_ascii_lowercase();
     if has_explicit_fetch_verb(&lower) {
         return true;
+    }
+    if is_opinion_only_url_chat(&lower) {
+        return false;
     }
     true
 }
@@ -362,6 +373,22 @@ fn has_explicit_fetch_verb(lower: &str) -> bool {
     ]
     .iter()
     .any(|v| lower.contains(v))
+}
+
+/// Plan Phase-1/3: opinion without an explicit read/fetch ask.
+fn is_opinion_only_url_chat(lower: &str) -> bool {
+    const CUES: &[&str] = &[
+        "do you know",
+        "have you heard",
+        "what do you think",
+        "your opinion",
+        "from your knowledge",
+        "without reading",
+        "without fetching",
+        "without opening",
+        "just tell me what you think",
+    ];
+    CUES.iter().any(|c| lower.contains(c))
 }
 
 /// System-prompt block when a URL is present and web:fetch is in the offer.
@@ -528,9 +555,30 @@ mod tests {
     }
 
     #[test]
-    fn soft_compel_true_for_url() {
+    fn soft_compel_true_for_fetch_ask_with_url() {
         assert!(should_soft_compel_web_fetch(
+            "please open https://github.com/vllm-project/semantic-router and summarize"
+        ));
+        assert!(should_soft_compel_web_fetch(
+            "check out https://eris-system.dev"
+        ));
+        // Bare URL / non-opinion phrasing still soft-compels.
+        assert!(should_soft_compel_web_fetch(
+            "https://github.com/vllm-project/semantic-router"
+        ));
+    }
+
+    #[test]
+    fn soft_compel_false_for_opinion_only_with_url() {
+        assert!(!should_soft_compel_web_fetch(
             "do you know this repo? https://github.com/vllm-project/semantic-router"
+        ));
+        assert!(!should_soft_compel_web_fetch(
+            "have you heard of https://example.com — what do you think?"
+        ));
+        // Fetch verb wins over opinion cue.
+        assert!(should_soft_compel_web_fetch(
+            "do you know this site? please fetch https://example.com anyway"
         ));
     }
 }

--- a/src/orchestrator/routing/policy.rs
+++ b/src/orchestrator/routing/policy.rs
@@ -1,27 +1,24 @@
-//! Phase-1 routing policy: demote weak lock-in, widen near-ties to domain clusters,
-//! and pair agenda dialog continuations.
+//! Ordered routing policy rules (Phase 1 logic, Phase 2 shape).
+//!
+//! Rules run in a fixed order and emit a [`RoutingDecision`]. Embeddings stay
+//! the primary signal; rules only veto, widen, or pair.
 
 use super::clusters::{
-    domains_share_affinity, expand_names_to_domain_clusters, tool_domain, union_clusters_for_tools,
+    cluster_members, domains_share_affinity, expand_names_to_domain_clusters, tool_domain,
+    union_clusters_for_tools,
 };
+use super::decision::{RoutingDecision, UnsureFallback};
+use super::signals::RoutingSignals;
 
 /// Lexical / forced hits use this floor so demotion never drops URL/search/news injects.
 const FORCED_HIT_FLOOR: f32 = 0.99;
 
-/// Result of applying Phase-1 policy to raw router hits.
-#[derive(Debug, Clone, PartialEq)]
-pub struct RoutingPolicyResult {
-    /// Tool names to offer. Empty + `tools_needed` means full roster (caller convention).
-    pub offered: Vec<String>,
-    /// Stable reason code for logs (`PRELLM_*`-style short tags).
-    pub reason: &'static str,
-}
-
-/// Knobs for demotion / margin (from [`crate::config::AppConfig`]).
+/// Knobs for demotion / margin / unsure fallback (from [`crate::config::AppConfig`]).
 #[derive(Debug, Clone, Copy)]
 pub struct RoutingPolicyKnobs {
     pub single_hit_floor: f32,
     pub match_margin: f32,
+    pub unsure_fallback: UnsureFallback,
 }
 
 impl Default for RoutingPolicyKnobs {
@@ -29,40 +26,40 @@ impl Default for RoutingPolicyKnobs {
         Self {
             single_hit_floor: 0.58,
             match_margin: 0.05,
+            unsure_fallback: UnsureFallback::FullRoster,
         }
     }
 }
 
-/// Apply Phase-1 offer policy.
-///
-/// `hits` are `(name, score)` already sorted descending (as from [`ToolRouter::match_tools`]).
-/// `recent_successful_tools` are session-scoped recent successes (newest last).
-/// `registered` is the gatekeeper tool name list used to expand clusters.
+/// Apply ordered policy rules to signals → [`RoutingDecision`].
 #[must_use]
-pub fn apply_routing_policy(
-    user_text: &str,
-    hits: &[(String, f32)],
-    recent_successful_tools: &[String],
+pub fn decide(
+    signals: &RoutingSignals,
     registered: &[String],
     knobs: RoutingPolicyKnobs,
-) -> RoutingPolicyResult {
-    // 1) Agenda dialog pairing — highest priority for the observed doc/agenda miss.
-    if let Some(result) =
-        try_agenda_dialog_pairing(user_text, hits, recent_successful_tools, registered)
-    {
-        return result;
+) -> RoutingDecision {
+    // Rule 1 — agenda dialog pairing (highest priority for the observed doc/agenda miss).
+    if let Some(decision) = rule_agenda_dialog_pairing(signals, registered) {
+        return decision;
     }
 
-    let (forced, embed): (Vec<_>, Vec<_>) = hits
+    let (forced, embed): (Vec<_>, Vec<_>) = signals
+        .embed_hits
         .iter()
         .cloned()
         .partition(|(_, score)| *score >= FORCED_HIT_FLOOR);
 
-    // 2) Lone weak embed hit → drop (asymmetric: empty is safer than lock-in).
-    let embed = demote_lone_weak_embed(embed, knobs.single_hit_floor);
+    // Rule 2 — lone weak embed hit demotion (+ unsure fallback).
+    let (embed, demoted_lone) = demote_lone_weak_embed(embed, knobs.single_hit_floor);
+    if let Some((demoted_name, _)) = demoted_lone {
+        if embed.is_empty() && forced.is_empty() {
+            return rule_unsure_after_demotion(&demoted_name, registered, knobs.unsure_fallback);
+        }
+    }
 
-    // 3) Near-tie across *related* domains → cluster union; else keep ranked hits.
-    let embed_offer = widen_near_tie_to_clusters(&embed, registered, knobs.match_margin);
+    // Rule 3 — near-tie across related domains → affinity cluster union; else ranked subset.
+    let (embed_offer, margin_rule) =
+        widen_near_tie_to_clusters(&embed, registered, knobs.match_margin);
 
     let mut offered = embed_offer;
     for (name, _) in &forced {
@@ -71,34 +68,171 @@ pub fn apply_routing_policy(
         }
     }
 
-    // Always re-rank by original cosine (no URL hard-pin). Cluster siblings without
-    // a direct hit inherit their domain's best seed score.
-    offered = rerank_offered_by_cosine(&offered, hits);
+    // Always re-rank by original cosine (no URL hard-pin).
+    offered = rerank_offered_by_cosine(&offered, &signals.embed_hits);
 
     if offered.is_empty() {
-        return RoutingPolicyResult {
-            offered: Vec::new(),
-            reason: "EMPTY_AFTER_POLICY",
-        };
+        return RoutingDecision::full_roster("EMPTY_AFTER_POLICY");
     }
 
-    let reason = if forced.is_empty() && embed.len() >= 2 {
-        "MARGIN_CLUSTER_OR_SUBSET"
+    let rule_id = if let Some(id) = margin_rule {
+        id
     } else if forced.is_empty() && embed.len() == 1 {
         "SINGLE_STRONG_HIT"
     } else if !forced.is_empty() && embed.is_empty() {
         "LEXICAL_FORCED_ONLY"
-    } else {
+    } else if !forced.is_empty() {
         "MIXED_EMBED_AND_LEXICAL"
+    } else {
+        "RANKED_SUBSET"
     };
 
-    RoutingPolicyResult { offered, reason }
+    if rule_id == "AFFINITY_MARGIN_UNION" {
+        let domains = domains_as_static(&offered);
+        return RoutingDecision::domain_cluster(rule_id, domains, offered);
+    }
+
+    RoutingDecision::subset(rule_id, offered)
+}
+
+/// Compatibility wrapper used by older call sites / tests.
+#[must_use]
+pub fn apply_routing_policy(
+    user_text: &str,
+    hits: &[(String, f32)],
+    recent_successful_tools: &[String],
+    registered: &[String],
+    knobs: RoutingPolicyKnobs,
+) -> RoutingDecision {
+    let signals = RoutingSignals::from_turn(user_text, hits.to_vec(), recent_successful_tools);
+    decide(&signals, registered, knobs)
+}
+
+fn domains_as_static(tools: &[String]) -> Vec<&'static str> {
+    let mut out: Vec<&'static str> = Vec::new();
+    for name in tools {
+        if let Some(d) = tool_domain(name) {
+            if let Some(s) = intern_known_domain(d) {
+                if !out.contains(&s) {
+                    out.push(s);
+                }
+            }
+        }
+    }
+    out.sort_unstable();
+    out
+}
+
+fn intern_known_domain(d: &str) -> Option<&'static str> {
+    Some(match d {
+        "agenda" => "agenda",
+        "clock" => "clock",
+        "calendar" => "calendar",
+        "web" => "web",
+        "news" => "news",
+        "wiki" => "wiki",
+        "doc" => "doc",
+        "vault" => "vault",
+        "memory" => "memory",
+        "media" => "media",
+        "mail" => "mail",
+        "weather" => "weather",
+        "moltbook" => "moltbook",
+        "db" => "db",
+        "vision" => "vision",
+        "system" => "system",
+        "skills" => "skills",
+        _ => return None,
+    })
+}
+
+fn rule_agenda_dialog_pairing(
+    signals: &RoutingSignals,
+    registered: &[String],
+) -> Option<RoutingDecision> {
+    if !signals.recent_had_agenda || !signals.agenda_continuation || signals.doc_ingest_cues {
+        return None;
+    }
+
+    let suppressed_doc = signals
+        .embed_hits
+        .iter()
+        .any(|(n, s)| n.starts_with("doc:") && *s < FORCED_HIT_FLOOR);
+
+    let mut offered = expand_names_to_domain_clusters(
+        ["agenda:remove", "agenda:complete", "agenda:list"]
+            .into_iter()
+            .map(str::to_string),
+        registered,
+    );
+    let mut front = Vec::new();
+    for preferred in ["agenda:remove", "agenda:complete", "agenda:list"] {
+        if let Some(pos) = offered.iter().position(|n| n == preferred) {
+            front.push(offered.remove(pos));
+        } else if registered.iter().any(|n| n == preferred) {
+            front.push(preferred.to_string());
+        }
+    }
+    front.append(&mut offered);
+    offered = front;
+
+    tracing::info!(
+        suppressed_doc_hits = suppressed_doc,
+        offered = ?offered,
+        event = "routing.policy.agenda_dialog_pairing",
+        "Agenda dialog continuation; offering agenda cluster (doc lock-in suppressed)"
+    );
+
+    Some(RoutingDecision::domain_cluster(
+        "AGENDA_DIALOG_PAIRING",
+        vec!["agenda"],
+        offered,
+    ))
+}
+
+fn rule_unsure_after_demotion(
+    demoted_name: &str,
+    registered: &[String],
+    fallback: UnsureFallback,
+) -> RoutingDecision {
+    match fallback {
+        UnsureFallback::FullRoster => {
+            tracing::info!(
+                demoted = %demoted_name,
+                fallback = "full_roster",
+                event = "routing.policy.unsure_fallback",
+                "Lone weak hit demoted; falling through to full roster"
+            );
+            RoutingDecision::full_roster("UNSURE_FULL_ROSTER")
+        }
+        UnsureFallback::DomainCluster => {
+            if let Some(domain) = tool_domain(demoted_name).and_then(intern_known_domain) {
+                let tools = cluster_members(domain, registered);
+                if !tools.is_empty() {
+                    tracing::info!(
+                        demoted = %demoted_name,
+                        domain,
+                        offered_count = tools.len(),
+                        fallback = "domain_cluster",
+                        event = "routing.policy.unsure_fallback",
+                        "Lone weak hit demoted; offering demoted tool's domain cluster"
+                    );
+                    return RoutingDecision::domain_cluster(
+                        "UNSURE_DOMAIN_CLUSTER",
+                        vec![domain],
+                        tools,
+                    );
+                }
+            }
+            RoutingDecision::full_roster("UNSURE_FULL_ROSTER")
+        }
+    }
 }
 
 fn demote_lone_weak_embed(
     embed: Vec<(String, f32)>,
     single_hit_floor: f32,
-) -> Vec<(String, f32)> {
+) -> (Vec<(String, f32)>, Option<(String, f32)>) {
     if embed.len() == 1 && embed[0].1 < single_hit_floor {
         tracing::info!(
             tool = %embed[0].0,
@@ -107,21 +241,23 @@ fn demote_lone_weak_embed(
             event = "routing.policy.single_hit_demoted",
             "Lone weak semantic hit demoted (avoid GBNF lock-in)"
         );
-        return Vec::new();
+        let demoted = (embed[0].0.clone(), embed[0].1);
+        return (Vec::new(), Some(demoted));
     }
-    embed
+    (embed, None)
 }
 
+/// Returns (offer names, optional rule id when affinity union fired).
 fn widen_near_tie_to_clusters(
     embed: &[(String, f32)],
     registered: &[String],
     match_margin: f32,
-) -> Vec<String> {
+) -> (Vec<String>, Option<&'static str>) {
     if embed.is_empty() {
-        return Vec::new();
+        return (Vec::new(), None);
     }
     if embed.len() == 1 {
-        return vec![embed[0].0.clone()];
+        return (vec![embed[0].0.clone()], None);
     }
 
     let top = embed[0].1;
@@ -132,14 +268,13 @@ fn widen_near_tie_to_clusters(
         .collect();
 
     if within.len() < 2 {
-        return embed.iter().map(|(n, _)| n.clone()).collect();
+        return (embed.iter().map(|(n, _)| n.clone()).collect(), None);
     }
 
     let Some(top_domain) = tool_domain(&within[0].0) else {
-        return embed.iter().map(|(n, _)| n.clone()).collect();
+        return (embed.iter().map(|(n, _)| n.clone()).collect(), None);
     };
 
-    // Only seeds that share affinity with the top hit participate in cluster union.
     let related_seeds: Vec<(String, f32)> = within
         .iter()
         .filter(|(n, _)| {
@@ -164,9 +299,6 @@ fn widen_near_tie_to_clusters(
     all_within_domains.sort_unstable();
     all_within_domains.dedup();
 
-    // Near-tie within one related domain: keep the ranked hit list.
-    // Near-tie across related domains (clock vs agenda): widen to that affinity union.
-    // Unrelated multi-domain mush: do not union — keep cosine-ranked embed hits.
     if related_domains.len() >= 2 {
         let seed: Vec<String> = related_seeds.iter().map(|(n, _)| n.clone()).collect();
         let union = union_clusters_for_tools(&seed, registered);
@@ -183,7 +315,7 @@ fn widen_near_tie_to_clusters(
             event = "routing.policy.margin_multi_domain_union",
             "Near-tie across related domains; offering affinity cluster union"
         );
-        return union;
+        return (union, Some("AFFINITY_MARGIN_UNION"));
     }
 
     if all_within_domains.len() >= 2 {
@@ -197,7 +329,10 @@ fn widen_near_tie_to_clusters(
         );
     }
 
-    embed.iter().map(|(n, _)| n.clone()).collect()
+    (
+        embed.iter().map(|(n, _)| n.clone()).collect(),
+        Some("RANKED_SUBSET"),
+    )
 }
 
 /// Order offer names by original router cosine. Unscored cluster siblings inherit
@@ -223,7 +358,6 @@ pub fn rerank_offered_by_cosine(offered: &[String], hits: &[(String, f32)]) -> V
         }
         if let Some(domain) = tool_domain(name) {
             if let Some((_, best)) = domain_best.iter().find(|(d, _)| *d == domain) {
-                // Slightly below the domain's best seed so exact hits sort first.
                 return (*best) - 1.0e-4;
             }
         }
@@ -241,102 +375,6 @@ pub fn rerank_offered_by_cosine(offered: &[String], hits: &[(String, f32)]) -> V
     ranked
 }
 
-fn try_agenda_dialog_pairing(
-    user_text: &str,
-    hits: &[(String, f32)],
-    recent_successful_tools: &[String],
-    registered: &[String],
-) -> Option<RoutingPolicyResult> {
-    let recent_had_agenda = recent_successful_tools
-        .iter()
-        .any(|n| n.starts_with("agenda:"));
-    if !recent_had_agenda {
-        return None;
-    }
-    if !has_agenda_continuation_intent(user_text) {
-        return None;
-    }
-    if has_doc_ingest_cues(user_text) {
-        return None;
-    }
-
-    // Suppress bare doc:* embed winners without ingest cues.
-    let suppressed_doc = hits
-        .iter()
-        .any(|(n, s)| n.starts_with("doc:") && *s < FORCED_HIT_FLOOR);
-
-    let mut offered = expand_names_to_domain_clusters(
-        ["agenda:remove", "agenda:complete", "agenda:list"]
-            .into_iter()
-            .map(str::to_string),
-        registered,
-    );
-    // Prefer the actionable trio first in offer order.
-    for preferred in ["agenda:remove", "agenda:complete", "agenda:list"] {
-        if registered.iter().any(|n| n == preferred) && !offered.iter().any(|n| n == preferred) {
-            offered.insert(0, preferred.to_string());
-        }
-    }
-    // Stable: put preferred three at front.
-    let mut front = Vec::new();
-    for preferred in ["agenda:remove", "agenda:complete", "agenda:list"] {
-        if let Some(pos) = offered.iter().position(|n| n == preferred) {
-            front.push(offered.remove(pos));
-        }
-    }
-    front.append(&mut offered);
-    offered = front;
-
-    tracing::info!(
-        suppressed_doc_hits = suppressed_doc,
-        offered = ?offered,
-        event = "routing.policy.agenda_dialog_pairing",
-        "Agenda dialog continuation; offering agenda cluster (doc lock-in suppressed)"
-    );
-
-    Some(RoutingPolicyResult {
-        offered,
-        reason: "AGENDA_DIALOG_PAIRING",
-    })
-}
-
-/// User wants to close/remove/finish something after seeing agenda.
-#[must_use]
-pub fn has_agenda_continuation_intent(text: &str) -> bool {
-    let lower = text.to_ascii_lowercase();
-    const CUES: &[&str] = &[
-        "remove",
-        "delete",
-        "done",
-        "complete",
-        "finished",
-        "finish",
-        "clear it",
-        "clear that",
-        "mark as done",
-        "check off",
-        "crossed off",
-        "take it off",
-        "off the agenda",
-        "from the agenda",
-        "from my agenda",
-    ];
-    CUES.iter().any(|c| lower.contains(c))
-}
-
-/// Explicit document-ingest intent — do not steal the turn for agenda pairing.
-#[must_use]
-pub fn has_doc_ingest_cues(text: &str) -> bool {
-    let lower = text.to_ascii_lowercase();
-    lower.contains("ingest")
-        || lower.contains("upload")
-        || lower.contains(".pdf")
-        || lower.contains("99_user_uploaded")
-        || lower.contains("document rag")
-        || (lower.contains("document")
-            && (lower.contains("add") || lower.contains("index") || lower.contains("import")))
-}
-
 /// Prefer calling `web:fetch` this turn unless the user clearly wants opinion-only chatter.
 #[must_use]
 pub fn should_soft_compel_web_fetch(user_text: &str) -> bool {
@@ -350,9 +388,6 @@ pub fn should_soft_compel_web_fetch(user_text: &str) -> bool {
     if has_explicit_fetch_verb(&lower) {
         return true;
     }
-    // Opinion-only with a URL cited as topic — still soft-compel by default so
-    // "do you know this repo? https://..." fetches rather than only chatting.
-    // Soft-compel is prompt bias, not a GBNF hard require.
     true
 }
 
@@ -383,6 +418,7 @@ Put narration in `message_to_user` after tools return. Opinion-only replies with
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::orchestrator::routing::decision::{RoutingOffer, UnsureFallback};
 
     fn reg() -> Vec<String> {
         vec![
@@ -414,12 +450,29 @@ mod tests {
     }
 
     #[test]
-    fn lone_weak_doc_ingest_demoted_to_empty() {
+    fn lone_weak_doc_ingest_demoted_to_full_roster() {
         let hits = vec![("doc:ingest".into(), 0.505)];
         let out = apply_routing_policy("remove it", &hits, &[], &reg(), RoutingPolicyKnobs::default());
-        // No recent agenda → demote to empty (full roster), not doc lock-in.
-        assert!(out.offered.is_empty(), "{out:?}");
-        assert_eq!(out.reason, "EMPTY_AFTER_POLICY");
+        assert!(matches!(out.offer, RoutingOffer::FullRoster), "{out:?}");
+        assert!(out.matched_tool_names().is_empty());
+    }
+
+    #[test]
+    fn lone_weak_unsure_domain_cluster_fallback() {
+        let hits = vec![("doc:ingest".into(), 0.505)];
+        let knobs = RoutingPolicyKnobs {
+            unsure_fallback: UnsureFallback::DomainCluster,
+            ..RoutingPolicyKnobs::default()
+        };
+        let out = apply_routing_policy("remove it", &hits, &[], &reg(), knobs);
+        assert_eq!(out.rule_id, "UNSURE_DOMAIN_CLUSTER");
+        match &out.offer {
+            RoutingOffer::DomainCluster { domains, tools } => {
+                assert_eq!(domains.as_slice(), ["doc"]);
+                assert!(tools.iter().all(|n| n.starts_with("doc:")));
+            }
+            other => panic!("expected domain cluster, got {other:?}"),
+        }
     }
 
     #[test]
@@ -433,9 +486,10 @@ mod tests {
             &reg(),
             RoutingPolicyKnobs::default(),
         );
-        assert_eq!(out.reason, "AGENDA_DIALOG_PAIRING");
-        assert!(out.offered.iter().any(|n| n == "agenda:remove"));
-        assert!(!out.offered.iter().any(|n| n.starts_with("doc:")));
+        assert_eq!(out.rule_id, "AGENDA_DIALOG_PAIRING");
+        let names = out.matched_tool_names();
+        assert!(names.iter().any(|n| n == "agenda:remove"));
+        assert!(!names.iter().any(|n| n.starts_with("doc:")));
     }
 
     #[test]
@@ -443,8 +497,8 @@ mod tests {
         let hits = vec![("vault:read".into(), 0.72)];
         let out =
             apply_routing_policy("read notes/today.md", &hits, &[], &reg(), RoutingPolicyKnobs::default());
-        assert_eq!(out.offered, vec!["vault:read".to_string()]);
-        assert_eq!(out.reason, "SINGLE_STRONG_HIT");
+        assert_eq!(out.matched_tool_names(), vec!["vault:read".to_string()]);
+        assert_eq!(out.rule_id, "SINGLE_STRONG_HIT");
     }
 
     #[test]
@@ -460,17 +514,17 @@ mod tests {
             &reg(),
             RoutingPolicyKnobs::default(),
         );
-        assert!(out.offered.contains(&"clock:timer".to_string()));
-        assert!(out.offered.contains(&"agenda:list".to_string()));
-        assert!(!out.offered.contains(&"doc:ingest".to_string()));
-        // Exact hits lead; no alphabetical `agenda:*` dump first.
-        assert_eq!(out.offered[0], "clock:alarm");
-        assert_eq!(out.offered[1], "agenda:remind_at");
+        assert_eq!(out.rule_id, "AFFINITY_MARGIN_UNION");
+        let names = out.matched_tool_names();
+        assert!(names.contains(&"clock:timer".to_string()));
+        assert!(names.contains(&"agenda:list".to_string()));
+        assert!(!names.contains(&"doc:ingest".to_string()));
+        assert_eq!(names[0], "clock:alarm");
+        assert_eq!(names[1], "agenda:remind_at");
     }
 
     #[test]
     fn unrelated_near_tie_mush_keeps_ranked_no_db_first() {
-        // Replay of the live URL turn: multi-domain mush within margin of a weak top.
         let hits = vec![
             ("moltbook:search".into(), 0.586),
             ("web:search".into(), 0.569),
@@ -488,25 +542,13 @@ mod tests {
             &reg(),
             RoutingPolicyKnobs::default(),
         );
-        assert_eq!(out.offered[0], "moltbook:search");
-        assert_ne!(out.offered[0], "db:find_connections");
-        // No affinity union → must not expand to full db/doc/memory/moltbook/web clusters.
-        assert!(
-            !out.offered.iter().any(|n| n == "doc:ingest"),
-            "should not dump unrelated doc cluster: {out:?}"
-        );
-        assert!(out.offered.iter().any(|n| n == "web:fetch"));
-        let db_pos = out
-            .offered
-            .iter()
-            .position(|n| n == "db:find_connections")
-            .expect("db remains as a ranked hit");
-        let fetch_pos = out
-            .offered
-            .iter()
-            .position(|n| n == "web:fetch")
-            .expect("web:fetch present");
-        assert!(fetch_pos < db_pos, "cosine order: fetch before db, got {out:?}");
+        let names = out.matched_tool_names();
+        assert_eq!(names[0], "moltbook:search");
+        assert!(!names.iter().any(|n| n == "doc:ingest"));
+        assert!(names.iter().any(|n| n == "web:fetch"));
+        let db_pos = names.iter().position(|n| n == "db:find_connections").unwrap();
+        let fetch_pos = names.iter().position(|n| n == "web:fetch").unwrap();
+        assert!(fetch_pos < db_pos, "cosine order: fetch before db, got {names:?}");
     }
 
     #[test]
@@ -523,10 +565,10 @@ mod tests {
             &reg(),
             RoutingPolicyKnobs::default(),
         );
-        assert!(out.offered.iter().any(|n| n == "web:fetch"));
-        assert!(!out.offered.iter().any(|n| n == "doc:ingest"));
-        // Cosine re-rank puts forced 1.0 first — score order, not a URL hard-pin.
-        assert_eq!(out.offered[0], "web:fetch");
+        let names = out.matched_tool_names();
+        assert!(names.iter().any(|n| n == "web:fetch"));
+        assert!(!names.iter().any(|n| n == "doc:ingest"));
+        assert_eq!(names[0], "web:fetch");
     }
 
     #[test]
@@ -534,14 +576,5 @@ mod tests {
         assert!(should_soft_compel_web_fetch(
             "do you know this repo? https://github.com/vllm-project/semantic-router"
         ));
-    }
-
-    #[test]
-    fn agenda_cues_and_doc_cues() {
-        assert!(has_agenda_continuation_intent("done"));
-        assert!(has_agenda_continuation_intent("remove that please"));
-        assert!(!has_agenda_continuation_intent("what's the weather"));
-        assert!(has_doc_ingest_cues("ingest report.pdf please"));
-        assert!(!has_doc_ingest_cues("remove it"));
     }
 }

--- a/src/orchestrator/routing/policy.rs
+++ b/src/orchestrator/routing/policy.rs
@@ -1,0 +1,547 @@
+//! Phase-1 routing policy: demote weak lock-in, widen near-ties to domain clusters,
+//! and pair agenda dialog continuations.
+
+use super::clusters::{
+    domains_share_affinity, expand_names_to_domain_clusters, tool_domain, union_clusters_for_tools,
+};
+
+/// Lexical / forced hits use this floor so demotion never drops URL/search/news injects.
+const FORCED_HIT_FLOOR: f32 = 0.99;
+
+/// Result of applying Phase-1 policy to raw router hits.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoutingPolicyResult {
+    /// Tool names to offer. Empty + `tools_needed` means full roster (caller convention).
+    pub offered: Vec<String>,
+    /// Stable reason code for logs (`PRELLM_*`-style short tags).
+    pub reason: &'static str,
+}
+
+/// Knobs for demotion / margin (from [`crate::config::AppConfig`]).
+#[derive(Debug, Clone, Copy)]
+pub struct RoutingPolicyKnobs {
+    pub single_hit_floor: f32,
+    pub match_margin: f32,
+}
+
+impl Default for RoutingPolicyKnobs {
+    fn default() -> Self {
+        Self {
+            single_hit_floor: 0.58,
+            match_margin: 0.05,
+        }
+    }
+}
+
+/// Apply Phase-1 offer policy.
+///
+/// `hits` are `(name, score)` already sorted descending (as from [`ToolRouter::match_tools`]).
+/// `recent_successful_tools` are session-scoped recent successes (newest last).
+/// `registered` is the gatekeeper tool name list used to expand clusters.
+#[must_use]
+pub fn apply_routing_policy(
+    user_text: &str,
+    hits: &[(String, f32)],
+    recent_successful_tools: &[String],
+    registered: &[String],
+    knobs: RoutingPolicyKnobs,
+) -> RoutingPolicyResult {
+    // 1) Agenda dialog pairing — highest priority for the observed doc/agenda miss.
+    if let Some(result) =
+        try_agenda_dialog_pairing(user_text, hits, recent_successful_tools, registered)
+    {
+        return result;
+    }
+
+    let (forced, embed): (Vec<_>, Vec<_>) = hits
+        .iter()
+        .cloned()
+        .partition(|(_, score)| *score >= FORCED_HIT_FLOOR);
+
+    // 2) Lone weak embed hit → drop (asymmetric: empty is safer than lock-in).
+    let embed = demote_lone_weak_embed(embed, knobs.single_hit_floor);
+
+    // 3) Near-tie across *related* domains → cluster union; else keep ranked hits.
+    let embed_offer = widen_near_tie_to_clusters(&embed, registered, knobs.match_margin);
+
+    let mut offered = embed_offer;
+    for (name, _) in &forced {
+        if !offered.contains(name) {
+            offered.push(name.clone());
+        }
+    }
+
+    // Always re-rank by original cosine (no URL hard-pin). Cluster siblings without
+    // a direct hit inherit their domain's best seed score.
+    offered = rerank_offered_by_cosine(&offered, hits);
+
+    if offered.is_empty() {
+        return RoutingPolicyResult {
+            offered: Vec::new(),
+            reason: "EMPTY_AFTER_POLICY",
+        };
+    }
+
+    let reason = if forced.is_empty() && embed.len() >= 2 {
+        "MARGIN_CLUSTER_OR_SUBSET"
+    } else if forced.is_empty() && embed.len() == 1 {
+        "SINGLE_STRONG_HIT"
+    } else if !forced.is_empty() && embed.is_empty() {
+        "LEXICAL_FORCED_ONLY"
+    } else {
+        "MIXED_EMBED_AND_LEXICAL"
+    };
+
+    RoutingPolicyResult { offered, reason }
+}
+
+fn demote_lone_weak_embed(
+    embed: Vec<(String, f32)>,
+    single_hit_floor: f32,
+) -> Vec<(String, f32)> {
+    if embed.len() == 1 && embed[0].1 < single_hit_floor {
+        tracing::info!(
+            tool = %embed[0].0,
+            score = embed[0].1,
+            floor = single_hit_floor,
+            event = "routing.policy.single_hit_demoted",
+            "Lone weak semantic hit demoted (avoid GBNF lock-in)"
+        );
+        return Vec::new();
+    }
+    embed
+}
+
+fn widen_near_tie_to_clusters(
+    embed: &[(String, f32)],
+    registered: &[String],
+    match_margin: f32,
+) -> Vec<String> {
+    if embed.is_empty() {
+        return Vec::new();
+    }
+    if embed.len() == 1 {
+        return vec![embed[0].0.clone()];
+    }
+
+    let top = embed[0].1;
+    let within: Vec<(String, f32)> = embed
+        .iter()
+        .filter(|(_, s)| top - *s <= match_margin)
+        .cloned()
+        .collect();
+
+    if within.len() < 2 {
+        return embed.iter().map(|(n, _)| n.clone()).collect();
+    }
+
+    let Some(top_domain) = tool_domain(&within[0].0) else {
+        return embed.iter().map(|(n, _)| n.clone()).collect();
+    };
+
+    // Only seeds that share affinity with the top hit participate in cluster union.
+    let related_seeds: Vec<(String, f32)> = within
+        .iter()
+        .filter(|(n, _)| {
+            tool_domain(n)
+                .map(|d| domains_share_affinity(top_domain, d))
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect();
+
+    let mut related_domains: Vec<&str> = related_seeds
+        .iter()
+        .filter_map(|(n, _)| tool_domain(n))
+        .collect();
+    related_domains.sort_unstable();
+    related_domains.dedup();
+
+    let mut all_within_domains: Vec<&str> = within
+        .iter()
+        .filter_map(|(n, _)| tool_domain(n))
+        .collect();
+    all_within_domains.sort_unstable();
+    all_within_domains.dedup();
+
+    // Near-tie within one related domain: keep the ranked hit list.
+    // Near-tie across related domains (clock vs agenda): widen to that affinity union.
+    // Unrelated multi-domain mush: do not union — keep cosine-ranked embed hits.
+    if related_domains.len() >= 2 {
+        let seed: Vec<String> = related_seeds.iter().map(|(n, _)| n.clone()).collect();
+        let union = union_clusters_for_tools(&seed, registered);
+        tracing::info!(
+            top_score = top,
+            margin = match_margin,
+            top_domain,
+            related_domains = ?related_domains,
+            skipped_unrelated = ?(all_within_domains
+                .iter()
+                .filter(|d| !related_domains.contains(d))
+                .collect::<Vec<_>>()),
+            offered_count = union.len(),
+            event = "routing.policy.margin_multi_domain_union",
+            "Near-tie across related domains; offering affinity cluster union"
+        );
+        return union;
+    }
+
+    if all_within_domains.len() >= 2 {
+        tracing::info!(
+            top_score = top,
+            margin = match_margin,
+            top_domain,
+            within_domains = ?all_within_domains,
+            event = "routing.policy.margin_unrelated_kept_ranked",
+            "Near-tie spans unrelated domains; keeping cosine-ranked hits (no cluster dump)"
+        );
+    }
+
+    embed.iter().map(|(n, _)| n.clone()).collect()
+}
+
+/// Order offer names by original router cosine. Unscored cluster siblings inherit
+/// the best score among seed hits in the same domain (then name for stability).
+#[must_use]
+pub fn rerank_offered_by_cosine(offered: &[String], hits: &[(String, f32)]) -> Vec<String> {
+    let mut domain_best: Vec<(&str, f32)> = Vec::new();
+    for (name, score) in hits {
+        if let Some(domain) = tool_domain(name) {
+            if let Some((_, best)) = domain_best.iter_mut().find(|(d, _)| *d == domain) {
+                if *score > *best {
+                    *best = *score;
+                }
+            } else {
+                domain_best.push((domain, *score));
+            }
+        }
+    }
+
+    let score_for = |name: &str| -> f32 {
+        if let Some((_, s)) = hits.iter().find(|(n, _)| n == name) {
+            return *s;
+        }
+        if let Some(domain) = tool_domain(name) {
+            if let Some((_, best)) = domain_best.iter().find(|(d, _)| *d == domain) {
+                // Slightly below the domain's best seed so exact hits sort first.
+                return (*best) - 1.0e-4;
+            }
+        }
+        0.0
+    };
+
+    let mut ranked = offered.to_vec();
+    ranked.sort_by(|a, b| {
+        let sa = score_for(a);
+        let sb = score_for(b);
+        sb.partial_cmp(&sa)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.cmp(b))
+    });
+    ranked
+}
+
+fn try_agenda_dialog_pairing(
+    user_text: &str,
+    hits: &[(String, f32)],
+    recent_successful_tools: &[String],
+    registered: &[String],
+) -> Option<RoutingPolicyResult> {
+    let recent_had_agenda = recent_successful_tools
+        .iter()
+        .any(|n| n.starts_with("agenda:"));
+    if !recent_had_agenda {
+        return None;
+    }
+    if !has_agenda_continuation_intent(user_text) {
+        return None;
+    }
+    if has_doc_ingest_cues(user_text) {
+        return None;
+    }
+
+    // Suppress bare doc:* embed winners without ingest cues.
+    let suppressed_doc = hits
+        .iter()
+        .any(|(n, s)| n.starts_with("doc:") && *s < FORCED_HIT_FLOOR);
+
+    let mut offered = expand_names_to_domain_clusters(
+        ["agenda:remove", "agenda:complete", "agenda:list"]
+            .into_iter()
+            .map(str::to_string),
+        registered,
+    );
+    // Prefer the actionable trio first in offer order.
+    for preferred in ["agenda:remove", "agenda:complete", "agenda:list"] {
+        if registered.iter().any(|n| n == preferred) && !offered.iter().any(|n| n == preferred) {
+            offered.insert(0, preferred.to_string());
+        }
+    }
+    // Stable: put preferred three at front.
+    let mut front = Vec::new();
+    for preferred in ["agenda:remove", "agenda:complete", "agenda:list"] {
+        if let Some(pos) = offered.iter().position(|n| n == preferred) {
+            front.push(offered.remove(pos));
+        }
+    }
+    front.append(&mut offered);
+    offered = front;
+
+    tracing::info!(
+        suppressed_doc_hits = suppressed_doc,
+        offered = ?offered,
+        event = "routing.policy.agenda_dialog_pairing",
+        "Agenda dialog continuation; offering agenda cluster (doc lock-in suppressed)"
+    );
+
+    Some(RoutingPolicyResult {
+        offered,
+        reason: "AGENDA_DIALOG_PAIRING",
+    })
+}
+
+/// User wants to close/remove/finish something after seeing agenda.
+#[must_use]
+pub fn has_agenda_continuation_intent(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    const CUES: &[&str] = &[
+        "remove",
+        "delete",
+        "done",
+        "complete",
+        "finished",
+        "finish",
+        "clear it",
+        "clear that",
+        "mark as done",
+        "check off",
+        "crossed off",
+        "take it off",
+        "off the agenda",
+        "from the agenda",
+        "from my agenda",
+    ];
+    CUES.iter().any(|c| lower.contains(c))
+}
+
+/// Explicit document-ingest intent — do not steal the turn for agenda pairing.
+#[must_use]
+pub fn has_doc_ingest_cues(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("ingest")
+        || lower.contains("upload")
+        || lower.contains(".pdf")
+        || lower.contains("99_user_uploaded")
+        || lower.contains("document rag")
+        || (lower.contains("document")
+            && (lower.contains("add") || lower.contains("index") || lower.contains("import")))
+}
+
+/// Prefer calling `web:fetch` this turn unless the user clearly wants opinion-only chatter.
+#[must_use]
+pub fn should_soft_compel_web_fetch(user_text: &str) -> bool {
+    let lower = user_text.to_ascii_lowercase();
+    let has_url = lower.contains("http://")
+        || lower.contains("https://")
+        || lower.contains("www.");
+    if !has_url {
+        return false;
+    }
+    if has_explicit_fetch_verb(&lower) {
+        return true;
+    }
+    // Opinion-only with a URL cited as topic — still soft-compel by default so
+    // "do you know this repo? https://..." fetches rather than only chatting.
+    // Soft-compel is prompt bias, not a GBNF hard require.
+    true
+}
+
+fn has_explicit_fetch_verb(lower: &str) -> bool {
+    [
+        "fetch",
+        "read ",
+        "read it",
+        "open ",
+        "open it",
+        "visit ",
+        "summarize",
+        "look at",
+        "check out",
+        "pull up",
+    ]
+    .iter()
+    .any(|v| lower.contains(v))
+}
+
+/// System-prompt block when a URL is present and web:fetch is in the offer.
+pub const URL_SOFT_COMPEL_HINT: &str = "\
+[URL_TOOL_HINT] The latest user message includes a URL. Prefer calling `web:fetch` this turn \
+(with `web:find` afterward if you need page content) instead of only discussing the link. \
+Put narration in `message_to_user` after tools return. Opinion-only replies with empty \
+`tool_calls` are allowed only if the user clearly asked for your prior knowledge without reading.";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reg() -> Vec<String> {
+        vec![
+            "agenda:list".into(),
+            "agenda:remove".into(),
+            "agenda:complete".into(),
+            "agenda:remind_at".into(),
+            "agenda:push".into(),
+            "clock:now".into(),
+            "clock:alarm".into(),
+            "clock:timer".into(),
+            "doc:ingest".into(),
+            "doc:query".into(),
+            "doc:delete".into(),
+            "doc:list".into(),
+            "doc:read".into(),
+            "web:fetch".into(),
+            "web:find".into(),
+            "web:search".into(),
+            "memory:query".into(),
+            "memory:commit".into(),
+            "memory:stage".into(),
+            "memory:staged_list".into(),
+            "memory:commit_all".into(),
+            "moltbook:search".into(),
+            "moltbook:home".into(),
+            "db:find_connections".into(),
+        ]
+    }
+
+    #[test]
+    fn lone_weak_doc_ingest_demoted_to_empty() {
+        let hits = vec![("doc:ingest".into(), 0.505)];
+        let out = apply_routing_policy("remove it", &hits, &[], &reg(), RoutingPolicyKnobs::default());
+        // No recent agenda → demote to empty (full roster), not doc lock-in.
+        assert!(out.offered.is_empty(), "{out:?}");
+        assert_eq!(out.reason, "EMPTY_AFTER_POLICY");
+    }
+
+    #[test]
+    fn lone_weak_after_agenda_pairs_to_agenda_cluster() {
+        let hits = vec![("doc:ingest".into(), 0.505)];
+        let recent = vec!["agenda:list".into()];
+        let out = apply_routing_policy(
+            "yes remove it from the agenda",
+            &hits,
+            &recent,
+            &reg(),
+            RoutingPolicyKnobs::default(),
+        );
+        assert_eq!(out.reason, "AGENDA_DIALOG_PAIRING");
+        assert!(out.offered.iter().any(|n| n == "agenda:remove"));
+        assert!(!out.offered.iter().any(|n| n.starts_with("doc:")));
+    }
+
+    #[test]
+    fn strong_single_hit_kept() {
+        let hits = vec![("vault:read".into(), 0.72)];
+        let out =
+            apply_routing_policy("read notes/today.md", &hits, &[], &reg(), RoutingPolicyKnobs::default());
+        assert_eq!(out.offered, vec!["vault:read".to_string()]);
+        assert_eq!(out.reason, "SINGLE_STRONG_HIT");
+    }
+
+    #[test]
+    fn clock_agenda_near_tie_unions_clusters_reranked_by_cosine() {
+        let hits = vec![
+            ("clock:alarm".into(), 0.61),
+            ("agenda:remind_at".into(), 0.59),
+        ];
+        let out = apply_routing_policy(
+            "remind me tomorrow at 10",
+            &hits,
+            &[],
+            &reg(),
+            RoutingPolicyKnobs::default(),
+        );
+        assert!(out.offered.contains(&"clock:timer".to_string()));
+        assert!(out.offered.contains(&"agenda:list".to_string()));
+        assert!(!out.offered.contains(&"doc:ingest".to_string()));
+        // Exact hits lead; no alphabetical `agenda:*` dump first.
+        assert_eq!(out.offered[0], "clock:alarm");
+        assert_eq!(out.offered[1], "agenda:remind_at");
+    }
+
+    #[test]
+    fn unrelated_near_tie_mush_keeps_ranked_no_db_first() {
+        // Replay of the live URL turn: multi-domain mush within margin of a weak top.
+        let hits = vec![
+            ("moltbook:search".into(), 0.586),
+            ("web:search".into(), 0.569),
+            ("memory:query".into(), 0.562),
+            ("doc:query".into(), 0.548),
+            ("memory:commit".into(), 0.543),
+            ("web:fetch".into(), 0.542),
+            ("db:find_connections".into(), 0.540),
+            ("web:find".into(), 0.537),
+        ];
+        let out = apply_routing_policy(
+            "do you know this repository online? https://github.com/vllm-project/semantic-router",
+            &hits,
+            &[],
+            &reg(),
+            RoutingPolicyKnobs::default(),
+        );
+        assert_eq!(out.offered[0], "moltbook:search");
+        assert_ne!(out.offered[0], "db:find_connections");
+        // No affinity union → must not expand to full db/doc/memory/moltbook/web clusters.
+        assert!(
+            !out.offered.iter().any(|n| n == "doc:ingest"),
+            "should not dump unrelated doc cluster: {out:?}"
+        );
+        assert!(out.offered.iter().any(|n| n == "web:fetch"));
+        let db_pos = out
+            .offered
+            .iter()
+            .position(|n| n == "db:find_connections")
+            .expect("db remains as a ranked hit");
+        let fetch_pos = out
+            .offered
+            .iter()
+            .position(|n| n == "web:fetch")
+            .expect("web:fetch present");
+        assert!(fetch_pos < db_pos, "cosine order: fetch before db, got {out:?}");
+    }
+
+    #[test]
+    fn lexical_forced_fetch_survives_demotion() {
+        let hits = vec![
+            ("doc:ingest".into(), 0.505),
+            ("web:fetch".into(), 1.0),
+            ("web:find".into(), 0.99),
+        ];
+        let out = apply_routing_policy(
+            "https://example.com/x",
+            &hits,
+            &[],
+            &reg(),
+            RoutingPolicyKnobs::default(),
+        );
+        assert!(out.offered.iter().any(|n| n == "web:fetch"));
+        assert!(!out.offered.iter().any(|n| n == "doc:ingest"));
+        // Cosine re-rank puts forced 1.0 first — score order, not a URL hard-pin.
+        assert_eq!(out.offered[0], "web:fetch");
+    }
+
+    #[test]
+    fn soft_compel_true_for_url() {
+        assert!(should_soft_compel_web_fetch(
+            "do you know this repo? https://github.com/vllm-project/semantic-router"
+        ));
+    }
+
+    #[test]
+    fn agenda_cues_and_doc_cues() {
+        assert!(has_agenda_continuation_intent("done"));
+        assert!(has_agenda_continuation_intent("remove that please"));
+        assert!(!has_agenda_continuation_intent("what's the weather"));
+        assert!(has_doc_ingest_cues("ingest report.pdf please"));
+        assert!(!has_doc_ingest_cues("remove it"));
+    }
+}

--- a/src/orchestrator/routing/policy.rs
+++ b/src/orchestrator/routing/policy.rs
@@ -4,10 +4,10 @@
 //! the primary signal; rules only veto, widen, or pair.
 
 use super::clusters::{
-    cluster_members, domains_share_affinity, expand_names_to_domain_clusters, tool_domain,
-    union_clusters_for_tools,
+    cluster_members, domains_share_affinity, tool_domain, union_clusters_for_tools,
 };
 use super::decision::{RoutingDecision, UnsureFallback};
+use super::dialog::try_dialog_pairing;
 use super::signals::RoutingSignals;
 
 /// Lexical / forced hits use this floor so demotion never drops URL/search/news injects.
@@ -38,8 +38,8 @@ pub fn decide(
     registered: &[String],
     knobs: RoutingPolicyKnobs,
 ) -> RoutingDecision {
-    // Rule 1 — agenda dialog pairing (highest priority for the observed doc/agenda miss).
-    if let Some(decision) = rule_agenda_dialog_pairing(signals, registered) {
+    // Rule 1 — dialog pairing (agenda → mail → calendar → gated doc).
+    if let Some(decision) = try_dialog_pairing(signals, registered) {
         return decision;
     }
 
@@ -144,50 +144,6 @@ fn intern_known_domain(d: &str) -> Option<&'static str> {
         "skills" => "skills",
         _ => return None,
     })
-}
-
-fn rule_agenda_dialog_pairing(
-    signals: &RoutingSignals,
-    registered: &[String],
-) -> Option<RoutingDecision> {
-    if !signals.recent_had_agenda || !signals.agenda_continuation || signals.doc_ingest_cues {
-        return None;
-    }
-
-    let suppressed_doc = signals
-        .embed_hits
-        .iter()
-        .any(|(n, s)| n.starts_with("doc:") && *s < FORCED_HIT_FLOOR);
-
-    let mut offered = expand_names_to_domain_clusters(
-        ["agenda:remove", "agenda:complete", "agenda:list"]
-            .into_iter()
-            .map(str::to_string),
-        registered,
-    );
-    let mut front = Vec::new();
-    for preferred in ["agenda:remove", "agenda:complete", "agenda:list"] {
-        if let Some(pos) = offered.iter().position(|n| n == preferred) {
-            front.push(offered.remove(pos));
-        } else if registered.iter().any(|n| n == preferred) {
-            front.push(preferred.to_string());
-        }
-    }
-    front.append(&mut offered);
-    offered = front;
-
-    tracing::info!(
-        suppressed_doc_hits = suppressed_doc,
-        offered = ?offered,
-        event = "routing.policy.agenda_dialog_pairing",
-        "Agenda dialog continuation; offering agenda cluster (doc lock-in suppressed)"
-    );
-
-    Some(RoutingDecision::domain_cluster(
-        "AGENDA_DIALOG_PAIRING",
-        vec!["agenda"],
-        offered,
-    ))
 }
 
 fn rule_unsure_after_demotion(

--- a/src/orchestrator/routing/signals.rs
+++ b/src/orchestrator/routing/signals.rs
@@ -14,6 +14,19 @@ pub struct RoutingSignals {
     pub agenda_continuation: bool,
     pub doc_ingest_cues: bool,
     pub recent_had_agenda: bool,
+    pub recent_had_mail: bool,
+    pub recent_had_calendar: bool,
+    /// Recent `doc:list` / `doc:read` / `doc:query` (catalog-ish), not bare ingest.
+    pub recent_had_doc_catalog: bool,
+    pub mail_delete_continuation: bool,
+    pub mail_move_continuation: bool,
+    pub mail_reply_continuation: bool,
+    pub mail_read_continuation: bool,
+    pub calendar_delete_continuation: bool,
+    pub calendar_update_continuation: bool,
+    pub calendar_get_continuation: bool,
+    /// Document-anchored delete/remove (not bare "remove it").
+    pub doc_delete_continuation: bool,
 }
 
 impl RoutingSignals {
@@ -30,6 +43,18 @@ impl RoutingSignals {
         let recent_had_agenda = recent_successful_tools
             .iter()
             .any(|n| n.starts_with("agenda:"));
+        let recent_had_mail = recent_successful_tools
+            .iter()
+            .any(|n| n.starts_with("mail:"));
+        let recent_had_calendar = recent_successful_tools
+            .iter()
+            .any(|n| n.starts_with("calendar:"));
+        let recent_had_doc_catalog = recent_successful_tools.iter().any(|n| {
+            matches!(
+                n.as_str(),
+                "doc:list" | "doc:read" | "doc:query" | "doc:delete"
+            )
+        });
         Self {
             user_text: user_text.to_string(),
             embed_hits,
@@ -38,6 +63,17 @@ impl RoutingSignals {
             agenda_continuation: has_agenda_continuation_intent(user_text),
             doc_ingest_cues: has_doc_ingest_cues(user_text),
             recent_had_agenda,
+            recent_had_mail,
+            recent_had_calendar,
+            recent_had_doc_catalog,
+            mail_delete_continuation: has_mail_delete_continuation(&lower),
+            mail_move_continuation: has_mail_move_continuation(&lower),
+            mail_reply_continuation: has_mail_reply_continuation(&lower),
+            mail_read_continuation: has_mail_read_continuation(&lower),
+            calendar_delete_continuation: has_calendar_delete_continuation(&lower),
+            calendar_update_continuation: has_calendar_update_continuation(&lower),
+            calendar_get_continuation: has_calendar_get_continuation(&lower),
+            doc_delete_continuation: has_doc_delete_continuation(&lower),
         }
     }
 }
@@ -79,6 +115,103 @@ pub fn has_doc_ingest_cues(text: &str) -> bool {
             && (lower.contains("add") || lower.contains("index") || lower.contains("import")))
 }
 
+fn has_mail_noun(lower: &str) -> bool {
+    lower.contains("email")
+        || lower.contains("e-mail")
+        || lower.contains("mail")
+        || lower.contains("inbox")
+        || lower.contains("message")
+}
+
+fn has_mail_delete_continuation(lower: &str) -> bool {
+    let destructive = lower.contains("delete")
+        || lower.contains("trash")
+        || lower.contains("discard")
+        || lower.contains("get rid of");
+    destructive && has_mail_noun(lower)
+}
+
+fn has_mail_move_continuation(lower: &str) -> bool {
+    let move_cue = lower.contains("move")
+        || lower.contains("archive")
+        || lower.contains("label")
+        || lower.contains("file under")
+        || lower.contains("spam");
+    move_cue && has_mail_noun(lower)
+}
+
+fn has_mail_reply_continuation(lower: &str) -> bool {
+    if lower.contains("moltbook") {
+        return false;
+    }
+    if lower.contains("reply to that email")
+        || lower.contains("reply via gmail")
+        || lower.contains("reply to the email")
+        || lower.contains("write back")
+    {
+        return true;
+    }
+    (lower.contains("reply") || lower.contains("respond")) && has_mail_noun(lower)
+}
+
+fn has_mail_read_continuation(lower: &str) -> bool {
+    let read_cue = lower.contains("read")
+        || lower.contains("open")
+        || lower.contains("show full")
+        || lower.contains("full message")
+        || lower.contains("that message");
+    read_cue && has_mail_noun(lower)
+}
+
+fn has_calendar_noun(lower: &str) -> bool {
+    lower.contains("meeting")
+        || lower.contains("event")
+        || lower.contains("appointment")
+        || lower.contains("calendar")
+        || lower.contains("invite")
+}
+
+fn has_calendar_delete_continuation(lower: &str) -> bool {
+    let destructive = lower.contains("cancel")
+        || lower.contains("delete")
+        || lower.contains("remove");
+    destructive && has_calendar_noun(lower)
+}
+
+fn has_calendar_update_continuation(lower: &str) -> bool {
+    let update = lower.contains("reschedule")
+        || lower.contains("change time")
+        || lower.contains("move the meeting")
+        || lower.contains("update")
+        || lower.contains("rename");
+    update && has_calendar_noun(lower)
+}
+
+fn has_calendar_get_continuation(lower: &str) -> bool {
+    let detail = lower.contains("details")
+        || lower.contains("attendees")
+        || lower.contains("meet link")
+        || lower.contains("open that")
+        || lower.contains("show that event");
+    detail && (has_calendar_noun(lower) || lower.contains("that"))
+}
+
+/// Document-anchored delete — requires document/pdf/ingest vocabulary (not bare remove).
+#[must_use]
+pub fn has_doc_delete_continuation(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    let destructive = lower.contains("delete")
+        || lower.contains("remove")
+        || lower.contains("unindex");
+    let doc_noun = lower.contains("document")
+        || lower.contains("pdf")
+        || lower.contains("ingested")
+        || lower.contains("upload")
+        || lower.contains("from rag")
+        || lower.contains("from the store");
+    destructive && doc_noun
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,5 +223,21 @@ mod tests {
         assert!(!has_agenda_continuation_intent("what's the weather"));
         assert!(has_doc_ingest_cues("ingest report.pdf please"));
         assert!(!has_doc_ingest_cues("remove it"));
+    }
+
+    #[test]
+    fn mail_and_doc_continuation_gates() {
+        assert!(has_mail_delete_continuation(
+            "please delete that email from my inbox"
+        ));
+        assert!(!has_mail_delete_continuation("please delete that"));
+        assert!(has_doc_delete_continuation(
+            "please delete that document from the store"
+        ));
+        assert!(!has_doc_delete_continuation("please remove it"));
+        assert!(has_calendar_delete_continuation(
+            "cancel that meeting on my calendar"
+        ));
+        assert!(!has_calendar_delete_continuation("cancel that"));
     }
 }

--- a/src/orchestrator/routing/signals.rs
+++ b/src/orchestrator/routing/signals.rs
@@ -1,0 +1,94 @@
+//! Lightweight signal extraction for pre-LLM routing (Phase 2).
+//!
+//! No new ML — boolean / lexical cues plus embed hits and dialog context.
+
+/// Snapshot of inputs the policy rules may read.
+#[derive(Debug, Clone)]
+pub struct RoutingSignals {
+    pub user_text: String,
+    /// Router hits already sorted descending (embed + lexical forced).
+    pub embed_hits: Vec<(String, f32)>,
+    /// Session-scoped recent successes (newest last).
+    pub recent_successful_tools: Vec<String>,
+    pub has_url: bool,
+    pub agenda_continuation: bool,
+    pub doc_ingest_cues: bool,
+    pub recent_had_agenda: bool,
+}
+
+impl RoutingSignals {
+    #[must_use]
+    pub fn from_turn(
+        user_text: &str,
+        embed_hits: Vec<(String, f32)>,
+        recent_successful_tools: &[String],
+    ) -> Self {
+        let lower = user_text.to_ascii_lowercase();
+        let has_url = lower.contains("http://")
+            || lower.contains("https://")
+            || lower.contains("www.");
+        let recent_had_agenda = recent_successful_tools
+            .iter()
+            .any(|n| n.starts_with("agenda:"));
+        Self {
+            user_text: user_text.to_string(),
+            embed_hits,
+            recent_successful_tools: recent_successful_tools.to_vec(),
+            has_url,
+            agenda_continuation: has_agenda_continuation_intent(user_text),
+            doc_ingest_cues: has_doc_ingest_cues(user_text),
+            recent_had_agenda,
+        }
+    }
+}
+
+/// User wants to close/remove/finish something after seeing agenda.
+#[must_use]
+pub fn has_agenda_continuation_intent(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    const CUES: &[&str] = &[
+        "remove",
+        "delete",
+        "done",
+        "complete",
+        "finished",
+        "finish",
+        "clear it",
+        "clear that",
+        "mark as done",
+        "check off",
+        "crossed off",
+        "take it off",
+        "off the agenda",
+        "from the agenda",
+        "from my agenda",
+    ];
+    CUES.iter().any(|c| lower.contains(c))
+}
+
+/// Explicit document-ingest intent — do not steal the turn for agenda pairing.
+#[must_use]
+pub fn has_doc_ingest_cues(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("ingest")
+        || lower.contains("upload")
+        || lower.contains(".pdf")
+        || lower.contains("99_user_uploaded")
+        || lower.contains("document rag")
+        || (lower.contains("document")
+            && (lower.contains("add") || lower.contains("index") || lower.contains("import")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agenda_cues_and_doc_cues() {
+        assert!(has_agenda_continuation_intent("done"));
+        assert!(has_agenda_continuation_intent("remove that please"));
+        assert!(!has_agenda_continuation_intent("what's the weather"));
+        assert!(has_doc_ingest_cues("ingest report.pdf please"));
+        assert!(!has_doc_ingest_cues("remove it"));
+    }
+}

--- a/src/telemetry/routing_codes.rs
+++ b/src/telemetry/routing_codes.rs
@@ -21,6 +21,9 @@ pub const ISSUE_PRELLM_MATCH_ERROR: &str = "PRELLM_MATCH_ERROR";
 pub const ISSUE_PRELLM_POLICY_REWRITE: &str = "PRELLM_POLICY_REWRITE";
 /// URL present and web:fetch offered — soft-compel hint injected into the system prompt.
 pub const ISSUE_PRELLM_URL_SOFT_COMPEL: &str = "PRELLM_URL_SOFT_COMPEL";
+/// URL present and web:fetch was offered this hop, but the model did not call `web:fetch`
+/// (Idle reply or other tools). Scorecard for soft-compel / opinion-only tuning.
+pub const ISSUE_PRELLM_URL_SKIP_FETCH: &str = "PRELLM_URL_SKIP_FETCH";
 /// Post-LLM: model emitted valid envelope JSON then non-whitespace prose after the closing `}`.
 pub const ISSUE_LLM_TRAILING_AFTER_JSON: &str = "LLM_TRAILING_AFTER_JSON";
 

--- a/src/telemetry/routing_codes.rs
+++ b/src/telemetry/routing_codes.rs
@@ -17,6 +17,10 @@ pub const ISSUE_PRELLM_ROUTER_UNAVAILABLE: &str = "PRELLM_ROUTER_UNAVAILABLE";
 pub const ISSUE_PRELLM_SEMANTIC_EMPTY: &str = "PRELLM_SEMANTIC_EMPTY";
 pub const ISSUE_PRELLM_SEMANTIC_HIT: &str = "PRELLM_SEMANTIC_HIT";
 pub const ISSUE_PRELLM_MATCH_ERROR: &str = "PRELLM_MATCH_ERROR";
+/// Phase-1 policy rewrote the offer (demotion, cluster union, agenda dialog pairing, …).
+pub const ISSUE_PRELLM_POLICY_REWRITE: &str = "PRELLM_POLICY_REWRITE";
+/// URL present and web:fetch offered — soft-compel hint injected into the system prompt.
+pub const ISSUE_PRELLM_URL_SOFT_COMPEL: &str = "PRELLM_URL_SOFT_COMPEL";
 /// Post-LLM: model emitted valid envelope JSON then non-whitespace prose after the closing `}`.
 pub const ISSUE_LLM_TRAILING_AFTER_JSON: &str = "LLM_TRAILING_AFTER_JSON";
 

--- a/src/tools/routing_phrases.rs
+++ b/src/tools/routing_phrases.rs
@@ -35,13 +35,13 @@ pub fn fallback_triggers(tool_name: &str) -> &'static str {
             "show tasks, what is on my list, pending items, show agenda, my schedule, what do I have to do"
         }
         "agenda:remove" => {
-            "remove task, cancel agenda item, delete from list, drop task, never mind that reminder, scratch that task"
+            "remove task, cancel agenda item, delete agenda item, drop task, never mind that reminder, cancel that task, take off my todo list, scratch that task"
         }
         "agenda:remind_at" => {
-            "remind me at, remind me in, remind me about, remind me tomorrow, remember to, nudge me at, ping me at, todo reminder, snooze task, alarm for my task, at 3pm for this, on my agenda, on my todo list, task_id reminder, in two minutes, in 2 minutes, multi-step task, several steps later, then send email, remind yourself to, delayed checklist"
+            "remind me at, remind me in, remind me about, remind me tomorrow, remember to, nudge me at, todo reminder, snooze task, agenda-linked reminder, remind me about this task, errand reminder, at 3pm for this, on my agenda, on my todo list, task_id reminder, in two minutes for this task, multi-step task, several steps later, then send email, remind yourself to, delayed checklist"
         }
         "agenda:complete" => {
-            "finishing tasks, mark done, complete task, check off, task finished, I did it"
+            "finishing tasks, mark done, complete task, check off the task, task finished, finished the reminded task, I did it"
         }
         "web:fetch" => {
             "fetching URLs, open this link, check this website, browse this page, read this article, get content from URL"
@@ -63,10 +63,10 @@ pub fn fallback_triggers(tool_name: &str) -> &'static str {
         }
         "clock:now" => "what time is it, current time, timezone, date now, local time",
         "clock:timer" => {
-            "generic timer in 30 minutes, countdown, stretch break, ping me in, not tied to agenda list, label-only reminder"
+            "generic timer in 30 minutes, countdown, stretch break, ping me in for a break, not tied to agenda list, label-only timer"
         }
         "clock:alarm" => {
-            "wake me up, wake alarm, alarm clock only, no task just alarm, not on my todo list, standalone alarm no agenda, no errand, bell only"
+            "wake me up, wake alarm, alarm clock only, no task just alarm, not on my todo list, standalone alarm no agenda, no errand, bell only, wake-up alarm, just ring at 7"
         }
         "weather:current" => {
             "weather now, temperature outside, is it raining, rainfall, sunny or cloudy, conditions today, current conditions, what's the weather like"
@@ -87,7 +87,7 @@ pub fn fallback_triggers(tool_name: &str) -> &'static str {
             "read email, open message, show email, email details, message content, full email, read message, opens mail, full gmail body, message id, open thread body"
         }
         "mail:write" => {
-            "send email, compose mail, write email, reply, email to, send a message, draft email, dispatch mail, send the greeting, send mail"
+            "send email, compose mail, write email, reply to that email, reply via gmail, email to, send a message, draft email, dispatch mail, send the greeting, send mail"
         }
         "mail:digest" => {
             "summarize email, today's mail, digest inbox, what came in today, recap messages, overview of recent gmail, batch list mail"

--- a/src/tools/specs.rs
+++ b/src/tools/specs.rs
@@ -10,7 +10,7 @@ tool_name = "agenda:complete"
 short_description = "Mark a queued agenda task as completed."
 when_to_use = "Use when the user clearly finished the task (especially after an agenda-linked alarm): call with task_id from agenda:list or AGENDA_CONFIRM line. Prefer explicit user wording (\"done\", \"finished\") before closing."
 when_not_to_use = "Do not use to create tasks. Do not infer completion from vague one-line replies; ask or use agenda:remind_at if they need another reminder."
-routing_hints = ["task done", "complete task", "mark done", "done with reminder", "alarm task finished", "finished the goldfish check"]
+routing_hints = ["task done", "complete task", "mark done", "done with reminder", "finished the reminded task", "check off the task"]
 
 [[examples_good]]
 name = "complete_task"
@@ -70,7 +70,7 @@ tool_name = "agenda:remove"
 short_description = "Remove a pending agenda task without completion logging."
 when_to_use = "Use to cancel a queued task: pass task_id from agenda:list, or description_match with a substring of the real task text (must match exactly one task)."
 when_not_to_use = "Do not use agenda:push to cancel; do not use for finished-task logging (use agenda:complete)."
-routing_hints = ["remove task", "cancel agenda", "delete from list", "drop task", "never mind"]
+routing_hints = ["remove task", "cancel agenda", "delete agenda item", "drop task", "never mind that reminder", "cancel that task", "take off my todo list"]
 
 [[examples_good]]
 name = "remove_by_id"
@@ -105,13 +105,14 @@ routing_hints = [
     "remember to",
     "do not forget",
     "nudge me at",
-    "ping me at",
     "todo reminder",
     "snooze this task",
-    "alarm for my task",
+    "agenda-linked reminder",
+    "remind me about this task",
+    "errand reminder",
     "in 10 minutes for this",
-    "in two minutes",
-    "in 2 minutes",
+    "in two minutes for this task",
+    "in 2 minutes for this task",
     "at 3pm for this",
     "schedule this reminder",
     "on my agenda",
@@ -423,7 +424,7 @@ short_description = "Search the web via browser39 [search].engine (default DuckD
 when_to_use = "Use when the user asks to search the web in natural language (no URL). Query must be plain text. Search provider URL must be on web_allowlist (e.g. html.duckduckgo.com)."
 when_not_to_use = "Do not use when the user gave a full URL (use web:fetch). After search, use web:find on artifact_id — do not web:fetch the SERP URL again. Not for BBC headline digest (news:today). Disabled when [web].search_enabled is false."
 suggested_skills = ["web-fetch-workflow"]
-routing_hints = ["search the web", "google", "look up online", "find on the internet", "duckduckgo"]
+routing_hints = ["search the web", "google", "look up online", "find on the internet", "duckduckgo", "web search for", "search online for"]
 
 [[examples_good]]
 name = "bundesliga_search"
@@ -441,7 +442,7 @@ short_description = "Fetch a news homepage and return ranked headline links; opt
 when_to_use = "Use for today's headlines, top stories, or a news digest from a homepage. Pass homepage_url for any allowlisted outlet (e.g. https://www.bbc.com/, https://taz.de/). Omit homepage_url to use news_today_default_homepage, or pass category (world, uk, politics, …) to build a section URL from news_today_site_base. Prefer over repeating identical web:fetch in the same turn. Set deep_fetch_top_n (1–3) for article bodies."
 when_not_to_use = "Do not use for a one-off article URL (use web:fetch) or plain-language web search (use web:search). Requires matching .fcp/web_allowlist.toml patterns. Not registered when news_today_enabled is false."
 suggested_skills = ["web-fetch-workflow"]
-routing_hints = ["todays news", "headlines", "top stories", "morning news", "news digest", "breaking news", "what is happening", "front page", "politics headlines", "science news", "business news", "economics news", "world news", "uk news"]
+routing_hints = ["todays news", "headlines", "top stories", "morning news", "news digest", "breaking news", "what is in the news", "what is happening in the news", "front page", "politics headlines", "science news", "business news", "economics news", "world news", "uk news"]
 
 [[examples_good]]
 name = "default_bbc_news_listing"
@@ -512,7 +513,7 @@ tool_name = "clock:alarm"
 short_description = "Wall-clock alarm at hour:minute local (24h) with a label only — no agenda row. Narrow use: wake-style or alarm-only pings, not tracked todos."
 when_to_use = "Use only when the user wants a fixed local time alarm without a todo to track or complete: wake up, alarm clock, short bell, no list item. Not for remind me to do X."
 when_not_to_use = "Do not use for remind me to errands, tasks, or anything that belongs on the agenda — use agenda:remind_at. Do not use for in N minutes (use clock:timer). Do not use for a specific agenda task_id (use agenda:remind_at)."
-routing_hints = ["wake me up", "wake alarm", "alarm clock only", "no task just alarm", "not on my todo list", "just wake me", "standalone alarm no agenda", "no errand to track", "bell only"]
+routing_hints = ["wake me up", "wake alarm", "alarm clock only", "no task just alarm", "not on my todo list", "just wake me", "standalone alarm no agenda", "no errand to track", "bell only", "wake-up alarm", "just ring at 7"]
 
 [[examples_good]]
 name = "morning"
@@ -715,7 +716,8 @@ routing_hints = [
     "send email",
     "compose mail",
     "write email",
-    "reply",
+    "reply to that email",
+    "reply via gmail",
     "email to",
     "send a message",
     "dispatch mail",
@@ -1355,7 +1357,7 @@ tool_name = "doc:delete"
 short_description = "Remove an ingested document from the RAG store and memory discovery tier."
 when_to_use = "Use when the user wants a document fully removed from search (chunks + 40_MEDIA card)."
 when_not_to_use = "Do not use to delete raw upload bytes only — removes indexed chunks and catalog card."
-routing_hints = ["delete document", "remove ingested pdf", "unindex document"]
+routing_hints = ["delete document", "remove ingested pdf", "unindex document", "delete uploaded document from rag", "remove that document from search"]
 
 [[examples_good]]
 name = "delete_by_id"


### PR DESCRIPTION
## Summary
GBNF made the tool *offer set* load-bearing, and cosine alone was being a bit of a liar — one weak hit like `doc:ingest@0.505` could lock the whole turn onto the wrong tool. This branch turns the existing router into a small signal → decision layer (not a vLLM semantic-router port, we don't need that).

**What we did:**
- Demote lone weak embed hits (floor/margin knobs) instead of locking GBNF onto them
- When unsure: fall through / domain cluster instead of "one bad tool forever"
- Affinity unions for related domains (clock∪agenda∪calendar), but unrelated mush stays ranked — no more dumping `db:find_connections` first on random URL chat
- Dialog pairing after successful tools: agenda → mail → calendar → gated doc (code + offline fixtures; mail/calendar still need Google for live E2E, that's fine)
- Formal `RoutingOffer` + named `rule_id`s so logs actually explain the decision
- Slim overlays in one place (cap / web:find / moltbook / doc→vault)
- Hint hygiene in `specs` / `routing_phrases` so domains collide less
- URL soft-compel hint, with real opinion-only exceptions ("do you know…") and `PRELLM_URL_SKIP_FETCH` scorecard when fetch was offered but not called
- Offline routing offer fixtures under `src/benchmark/routing_offer_fixtures.rs` (no live llama)
