### PR TITLE
ci: add bounded Ota adoption pressure

### DIFF
--- a/.github/workflows/ota-pressure.yml
+++ b/.github/workflows/ota-pressure.yml
@@ -59,6 +59,13 @@ jobs:
         shell: bash
         run: mkdir -p ota-pressure
 
+      - name: Record exact toolchain posture
+        shell: bash
+        run: |
+          rustc --version --verbose > ota-pressure/rustc-version.txt
+          cargo --version --verbose > ota-pressure/cargo-version.txt
+          ota --version > ota-pressure/ota-version.txt
+
       - name: Validate contract
         id: validate
         continue-on-error: true
@@ -95,9 +102,10 @@ jobs:
         shell: bash
         run: |
           before_lock="$(git hash-object Cargo.lock)"
-          ota run verify --agent . 2>&1 | tee ota-pressure/verify.txt
+          ota run verify --agent --stream . 2>&1 | tee ota-pressure/verify.txt
           test "$(git hash-object Cargo.lock)" = "$before_lock"
           git diff --exit-code -- Cargo.lock
+          git diff --exit-code
 
       - name: Record exact lane outcomes
         if: always()
@@ -218,6 +226,7 @@ jobs:
           gatekeeper_refused=${{ steps.refused.outcome }}
           image=${{ steps.image.outcome }}
           EOF
+          git diff --exit-code
 
       - name: Upload retained container evidence
         if: always()

--- a/.github/workflows/ota-pressure.yml
+++ b/.github/workflows/ota-pressure.yml
@@ -81,7 +81,7 @@ jobs:
         id: preview
         continue-on-error: true
         shell: bash
-        run: ota up --workflow verify --agent --dry-run . --json > ota-pressure/up-dry-run.json
+        run: ota up --workflow verify --native --agent --dry-run . --json > ota-pressure/up-dry-run.json
 
       - name: Observe existing formatting baseline
         id: format

--- a/.github/workflows/ota-pressure.yml
+++ b/.github/workflows/ota-pressure.yml
@@ -34,7 +34,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Windows cannot check out the current upstream tree because one tracked documentation
+        # filename contains double quotes. Keep that repository blocker explicit rather than
+        # weakening or rewriting source in this adoption workflow.
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 

--- a/.github/workflows/ota-pressure.yml
+++ b/.github/workflows/ota-pressure.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   contract-ci-drift:
-    name: Contract-to-CI drift
+    name: Contract-to-CI comparison (advisory)
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -24,7 +24,7 @@ jobs:
           command: doctor
           source: contract
           fail-on-error: false
-          fail-on-ci-drift: true
+          fail-on-ci-drift: false
           comment-pr: false
 
   ota-contract:

--- a/.github/workflows/ota-pressure.yml
+++ b/.github/workflows/ota-pressure.yml
@@ -1,0 +1,236 @@
+name: "Evidence: Ota adoption (non-blocking)"
+
+on:
+  push:
+    branches:
+      - bobai/**
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-ci-drift:
+    name: Contract-to-CI drift
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Check contract-owned CI truth
+        uses: ota-run/action@6bb5bf686df5a8385202c8c20b6f91c045e3c161 # v1.0.15
+        with:
+          command: doctor
+          source: contract
+          fail-on-error: false
+          fail-on-ci-drift: true
+          comment-pr: false
+
+  ota-contract:
+    name: Ota contract (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921 # stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.1
+        with:
+          cache-directories: .ota/cache/cargo-native
+
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184 # v1.0.8
+        with:
+          source: contract
+          contract-path: ota.yaml
+
+      - name: Prepare retained evidence
+        shell: bash
+        run: mkdir -p ota-pressure
+
+      - name: Validate contract
+        id: validate
+        continue-on-error: true
+        shell: bash
+        run: ota validate . 2>&1 | tee ota-pressure/validate.txt
+
+      - name: Diagnose bounded readiness
+        id: doctor
+        continue-on-error: true
+        shell: bash
+        run: ota doctor . --json > ota-pressure/doctor.json
+
+      - name: Inspect agent-safe surface
+        id: tasks
+        continue-on-error: true
+        shell: bash
+        run: ota tasks --safe --use . 2>&1 | tee ota-pressure/tasks.txt
+
+      - name: Preview verification workflow
+        id: preview
+        continue-on-error: true
+        shell: bash
+        run: ota up --workflow verify --agent --dry-run . --json > ota-pressure/up-dry-run.json
+
+      - name: Observe existing formatting baseline
+        id: format
+        continue-on-error: true
+        shell: bash
+        run: ota run format --agent . > ota-pressure/format.txt 2>&1
+
+      - name: Run bounded verification
+        id: verify
+        continue-on-error: true
+        shell: bash
+        run: |
+          before_lock="$(git hash-object Cargo.lock)"
+          ota run verify --agent . 2>&1 | tee ota-pressure/verify.txt
+          test "$(git hash-object Cargo.lock)" = "$before_lock"
+          git diff --exit-code -- Cargo.lock
+
+      - name: Record exact lane outcomes
+        if: always()
+        shell: bash
+        run: |
+          cat > ota-pressure/outcomes.txt <<EOF
+          revision=${GITHUB_SHA}
+          os=${{ matrix.os }}
+          validate=${{ steps.validate.outcome }}
+          doctor=${{ steps.doctor.outcome }}
+          tasks=${{ steps.tasks.outcome }}
+          preview=${{ steps.preview.outcome }}
+          format_advisory=${{ steps.format.outcome }}
+          verify=${{ steps.verify.outcome }}
+          EOF
+
+      - name: Upload retained evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: eris-ota-${{ matrix.os }}
+          path: ota-pressure/
+          if-no-files-found: error
+
+      - name: Preserve truthful lane failure
+        if: always()
+        shell: bash
+        run: |
+          test "${{ steps.validate.outcome }}" = success
+          test "${{ steps.doctor.outcome }}" = success
+          test "${{ steps.tasks.outcome }}" = success
+          test "${{ steps.preview.outcome }}" = success
+          test "${{ steps.verify.outcome }}" = success
+
+  ota-container:
+    name: Ota portable controls (container)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184 # v1.0.8
+        with:
+          source: contract
+          contract-path: ota.yaml
+
+      - name: Prepare retained container evidence
+        shell: bash
+        run: mkdir -p ota-pressure/container
+
+      - name: Record container engine posture
+        id: engine
+        continue-on-error: true
+        shell: bash
+        run: docker version --format '{{json .}}' > ota-pressure/container/docker-version.json
+
+      - name: Preview disposable-vault control
+        id: preview_vault
+        continue-on-error: true
+        shell: bash
+        run: |
+          ota run test:vault:read --mode container --agent --dry-run . --json \
+            > ota-pressure/container/vault-dry-run.json
+
+      - name: Run disposable-vault control through Ota container mode
+        id: vault
+        continue-on-error: true
+        shell: bash
+        run: |
+          before_lock="$(git hash-object Cargo.lock)"
+          ota run test:vault:read --mode container --agent --stream . \
+            > ota-pressure/container/vault.log 2>&1
+          test "$(git hash-object Cargo.lock)" = "$before_lock"
+          git diff --exit-code -- Cargo.lock
+
+      - name: Run Gatekeeper allowed control through Ota container mode
+        id: allowed
+        continue-on-error: true
+        shell: bash
+        run: |
+          before_lock="$(git hash-object Cargo.lock)"
+          ota run test:gatekeeper:allowed --mode container --agent --stream . \
+            > ota-pressure/container/gatekeeper-allowed.log 2>&1
+          test "$(git hash-object Cargo.lock)" = "$before_lock"
+          git diff --exit-code -- Cargo.lock
+
+      - name: Run Gatekeeper refused control through Ota container mode
+        id: refused
+        continue-on-error: true
+        shell: bash
+        run: |
+          before_lock="$(git hash-object Cargo.lock)"
+          ota run test:gatekeeper:refused --mode container --agent --stream . \
+            > ota-pressure/container/gatekeeper-refused.log 2>&1
+          test "$(git hash-object Cargo.lock)" = "$before_lock"
+          git diff --exit-code -- Cargo.lock
+
+      - name: Record resolved image
+        id: image
+        continue-on-error: true
+        shell: bash
+        run: |
+          docker image inspect \
+            'rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1' \
+            > ota-pressure/container/image.json
+
+      - name: Record exact container outcomes
+        if: always()
+        shell: bash
+        run: |
+          cat > ota-pressure/container/outcomes.txt <<EOF
+          revision=${GITHUB_SHA}
+          engine=${{ steps.engine.outcome }}
+          preview_vault=${{ steps.preview_vault.outcome }}
+          vault=${{ steps.vault.outcome }}
+          gatekeeper_allowed=${{ steps.allowed.outcome }}
+          gatekeeper_refused=${{ steps.refused.outcome }}
+          image=${{ steps.image.outcome }}
+          EOF
+
+      - name: Upload retained container evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: eris-ota-container
+          path: ota-pressure/container/
+          if-no-files-found: error
+
+      - name: Preserve truthful container failure
+        if: always()
+        shell: bash
+        run: |
+          test "${{ steps.engine.outcome }}" = success
+          test "${{ steps.preview_vault.outcome }}" = success
+          test "${{ steps.vault.outcome }}" = success
+          test "${{ steps.allowed.outcome }}" = success
+          test "${{ steps.refused.outcome }}" = success
+          test "${{ steps.image.outcome }}" = success

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 /vaults
 .cursor/
 .idea/
+.ota/state/
+.ota/contracts/
+.ota/receipts/
+.ota/proof/
+.ota/cache/

--- a/ota.yaml
+++ b/ota.yaml
@@ -239,7 +239,8 @@ workflows:
       optional container context. The separate container pressure lane invokes each portable task
       directly because aggregates do not own execution-mode selection. Hosted Windows execution
       remains unproved because the current upstream tree contains a documentation filename that
-      NTFS cannot check out.
+      NTFS cannot check out. Hosted evidence retains exact Rust, Cargo, and Ota versions, streams
+      the source-owned batch runner, and rejects tracked-file or Cargo.lock drift.
 
 agent:
   posture: readiness_strict

--- a/ota.yaml
+++ b/ota.yaml
@@ -235,9 +235,11 @@ workflows:
       models, contact Qdrant, exercise live chat, validate hardware profiles, or prove the
       feature/shipping distribution lifecycle. Its vault and Gatekeeper controls are isolated Rust
       fixtures, not evidence about a configured operator vault or a live model-driven session. The
-      separate container pressure lane invokes each portable task directly because aggregates do
-      not own execution-mode selection. Hosted Windows execution remains unproved because the
-      current upstream tree contains a documentation filename that NTFS cannot check out.
+      native pressure preview selects `--native` explicitly because this contract also declares an
+      optional container context. The separate container pressure lane invokes each portable task
+      directly because aggregates do not own execution-mode selection. Hosted Windows execution
+      remains unproved because the current upstream tree contains a documentation filename that
+      NTFS cannot check out.
 
 agent:
   posture: readiness_strict

--- a/ota.yaml
+++ b/ota.yaml
@@ -69,6 +69,9 @@ tasks:
 
   format:
     description: Verify canonical Rust formatting without changing files
+    notes: |
+      The current upstream tree has known formatting drift. This task remains useful as an
+      advisory baseline and is intentionally excluded from the default verify closure.
     category: lint
     command:
       exe: cargo
@@ -105,6 +108,9 @@ tasks:
 
   test:cargo-matrix-batch:
     description: Run the complete repository test surface through Eris's bounded batch runner
+    notes: |
+      This invokes the repository-owned cargo test-full shell runner. Ota retains its 47 batch
+      results and terminal outcome but does not independently model every command inside it.
     category: test
     command:
       exe: cargo
@@ -118,6 +124,9 @@ tasks:
 
   test:gatekeeper:allowed:
     description: Exercise one registered operation accepted by the Gatekeeper
+    notes: |
+      This is an isolated Rust fixture. Success does not prove live model execution, operator
+      configuration, or effective runtime policy outside the fixture.
     category: test
     command:
       exe: cargo
@@ -146,6 +155,9 @@ tasks:
 
   test:vault:read:
     description: Exercise a Markdown read through an isolated disposable vault fixture
+    notes: |
+      This is an isolated disposable Rust fixture. Success does not prove access to, mutation of,
+      or policy enforcement for a configured operator vault.
     category: test
     command:
       exe: cargo
@@ -174,6 +186,9 @@ tasks:
 
   test:gatekeeper:refused:
     description: Exercise one operation the Gatekeeper refuses in the selected state
+    notes: |
+      This is an isolated Rust negative-control fixture. Success proves its expected refusal, not
+      that a live model or every Eris tool path is governed by the same boundary.
     category: test
     command:
       exe: cargo
@@ -212,6 +227,10 @@ tasks:
 
   verify:
     description: Run the repository's canonical non-credentialed CI verification surface
+    notes: |
+      Success is bounded to compilation, Clippy, the source-owned test runner, and the three exact
+      vault/Gatekeeper fixtures. It does not establish model, Qdrant, live-session, hardware,
+      shipping, or repository-wide readiness.
     category: verify
     aggregate:
       tasks:

--- a/ota.yaml
+++ b/ota.yaml
@@ -1,0 +1,287 @@
+version: 1
+metadata:
+  ota:
+    minimum_version: "1.6.27"
+
+project:
+  name: eris
+  description: Local-first Rust agent with explicit Gatekeeper authorization boundaries
+  type: application
+
+execution:
+  default_context: host
+  contexts:
+    host:
+      backend: native
+      env:
+        CARGO_HOME: .ota/cache/cargo-native
+    rust:
+      backend: container
+      lifecycle: ephemeral
+      env:
+        CARGO_HOME: /workspace/.ota/cache/cargo-container
+      container:
+        image: rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1
+        platform: linux/amd64
+        engines:
+          - docker
+      attachments:
+        isolated_paths:
+          - .ota/cache/cargo-container
+
+toolchains:
+  rust:
+    version: ">=1.85"
+
+tasks:
+  setup:cargo:native:
+    description: Hydrate Cargo dependencies from the committed lockfile into Ota's native cache
+    category: setup
+    prepare:
+      kind: dependency_hydration
+      medium: package_dependencies
+      source:
+        kind: cargo
+        cwd: .
+    requirements:
+      toolchains: [rust]
+    effects:
+      writes: [.ota/cache/cargo-native]
+      network: true
+      network_kind: dependency_hydration
+    safe_for_agent: true
+
+  setup:cargo:container:
+    description: Hydrate Cargo dependencies from the committed lockfile into the isolated container cache
+    category: setup
+    prepare:
+      kind: dependency_hydration
+      medium: package_dependencies
+      source:
+        kind: cargo
+        cwd: .
+    requirements:
+      toolchains: [rust]
+    effects:
+      writes: [.ota/cache/cargo-container]
+      network: true
+      network_kind: dependency_hydration
+    execution:
+      default_mode: container
+      modes:
+        container:
+          context: rust
+    safe_for_agent: true
+
+  format:
+    description: Verify canonical Rust formatting without changing files
+    category: lint
+    command:
+      exe: cargo
+      args: [fmt, --all, --, --check]
+    requirements:
+      toolchains: [rust]
+    safe_for_agent: true
+
+  lint:
+    description: Run the repository's production-binary Clippy gate
+    category: lint
+    command:
+      exe: cargo
+      args: [clippy, --bin, eris]
+    depends_on: [setup:cargo:native]
+    requirements:
+      toolchains: [rust]
+    effects:
+      writes: [target]
+    safe_for_agent: true
+
+  build:
+    description: Compile the production binary and test targets without executing them
+    category: build
+    command:
+      exe: cargo
+      args: [build, --bin, eris, --tests]
+    depends_on: [setup:cargo:native]
+    requirements:
+      toolchains: [rust]
+    effects:
+      writes: [target]
+    safe_for_agent: true
+
+  test:cargo-matrix-batch:
+    description: Run the complete repository test surface through Eris's bounded batch runner
+    category: test
+    command:
+      exe: cargo
+      args: [test-full]
+    depends_on: [setup:cargo:native]
+    requirements:
+      toolchains: [rust]
+    effects:
+      writes: [target]
+    safe_for_agent: true
+
+  test:gatekeeper:allowed:
+    description: Exercise one registered operation accepted by the Gatekeeper
+    category: test
+    command:
+      exe: cargo
+      args:
+        - test
+        - --bin
+        - eris
+        - tools::gatekeeper::tests::test_gatekeeper_executes_registered_tool
+        - --
+        - --exact
+        - --test-threads=1
+    requirements:
+      toolchains: [rust]
+    effects:
+      writes: [target]
+    execution:
+      default_mode: native
+      modes:
+        native:
+          context: host
+          depends_on: [setup:cargo:native]
+        container:
+          context: rust
+          depends_on: [setup:cargo:container]
+    safe_for_agent: true
+
+  test:vault:read:
+    description: Exercise a Markdown read through an isolated disposable vault fixture
+    category: test
+    command:
+      exe: cargo
+      args:
+        - test
+        - --bin
+        - eris
+        - tools::vault::read::tests::test_vault_read_normal
+        - --
+        - --exact
+        - --test-threads=1
+    requirements:
+      toolchains: [rust]
+    effects:
+      writes: [target]
+    execution:
+      default_mode: native
+      modes:
+        native:
+          context: host
+          depends_on: [setup:cargo:native]
+        container:
+          context: rust
+          depends_on: [setup:cargo:container]
+    safe_for_agent: true
+
+  test:gatekeeper:refused:
+    description: Exercise one operation the Gatekeeper refuses in the selected state
+    category: test
+    command:
+      exe: cargo
+      args:
+        - test
+        - --bin
+        - eris
+        - tools::gatekeeper::tests::test_gatekeeper_blocks_agenda_complete_in_chat
+        - --
+        - --exact
+        - --test-threads=1
+    requirements:
+      toolchains: [rust]
+    effects:
+      writes: [target]
+    execution:
+      default_mode: native
+      modes:
+        native:
+          context: host
+          depends_on: [setup:cargo:native]
+        container:
+          context: rust
+          depends_on: [setup:cargo:container]
+    safe_for_agent: true
+
+  verify:portable:
+    description: Run the native disposable-vault and Gatekeeper control slice
+    category: verify
+    aggregate:
+      tasks:
+        - test:vault:read
+        - test:gatekeeper:allowed
+        - test:gatekeeper:refused
+    safe_for_agent: true
+
+  verify:
+    description: Run the repository's canonical non-credentialed CI verification surface
+    category: verify
+    aggregate:
+      tasks:
+        - build
+        - lint
+        - test:vault:read
+        - test:gatekeeper:allowed
+        - test:gatekeeper:refused
+        - test:cargo-matrix-batch
+    safe_for_agent: true
+
+workflows:
+  default: verify
+  verify:
+    intent: ci_validation
+    description: Validate Eris source quality and exact Gatekeeper allow/refuse controls
+    run:
+      task: verify
+    notes: |
+      This workflow is intentionally non-credentialed. It does not start llama-server, download
+      models, contact Qdrant, exercise live chat, validate hardware profiles, or prove the
+      feature/shipping distribution lifecycle. Its vault and Gatekeeper controls are isolated Rust
+      fixtures, not evidence about a configured operator vault or a live model-driven session. The
+      separate container pressure lane invokes each portable task directly because aggregates do
+      not own execution-mode selection.
+
+agent:
+  posture: readiness_strict
+  entrypoint: verify
+  default_task: verify
+  safe_tasks:
+    - setup:cargo:container
+    - setup:cargo:native
+    - format
+    - build
+    - lint
+    - test:cargo-matrix-batch
+    - test:vault:read
+    - test:gatekeeper:allowed
+    - test:gatekeeper:refused
+    - verify:portable
+    - verify
+  verify_after_changes:
+    - verify
+  writable_paths:
+    - src
+    - tests
+    - docs
+    - .ota/cache
+    - target
+  protected_paths:
+    - .github/workflows
+    - Cargo.lock
+  notes: |
+    Use `ota tasks --safe --use` before selecting work. Run agent-authorized tasks with `--agent`.
+    The Cargo hydration tasks are intentionally agent-authorized because they hydrate the committed
+    lockfile only. `Cargo.lock` remains protected and the pressure lane rejects lockfile drift;
+    native hydration uses an ignored repository-local cache and container hydration uses an
+    Ota-managed isolated cache; neither task mutates the developer's global Cargo cache.
+    The default `verify` task is bounded to non-credentialed source and Gatekeeper controls; do not
+    infer model, Qdrant, live-chat, hardware, or shipping readiness from a green result.
+  bootstrap:
+    ota:
+      note: Install Ota only when it is missing and installation is approved.
+      source:
+        kind: version
+        version: v1.6.27

--- a/ota.yaml
+++ b/ota.yaml
@@ -242,7 +242,8 @@ workflows:
       feature/shipping distribution lifecycle. Its vault and Gatekeeper controls are isolated Rust
       fixtures, not evidence about a configured operator vault or a live model-driven session. The
       separate container pressure lane invokes each portable task directly because aggregates do
-      not own execution-mode selection.
+      not own execution-mode selection. Hosted Windows execution remains unproved because the
+      current upstream tree contains a documentation filename that NTFS cannot check out.
 
 agent:
   posture: readiness_strict

--- a/ota.yaml
+++ b/ota.yaml
@@ -37,12 +37,9 @@ tasks:
   setup:cargo:native:
     description: Hydrate Cargo dependencies from the committed lockfile into Ota's native cache
     category: setup
-    prepare:
-      kind: dependency_hydration
-      medium: package_dependencies
-      source:
-        kind: cargo
-        cwd: .
+    command:
+      exe: cargo
+      args: [fetch, --locked]
     requirements:
       toolchains: [rust]
     effects:
@@ -54,12 +51,9 @@ tasks:
   setup:cargo:container:
     description: Hydrate Cargo dependencies from the committed lockfile into the isolated container cache
     category: setup
-    prepare:
-      kind: dependency_hydration
-      medium: package_dependencies
-      source:
-        kind: cargo
-        cwd: .
+    command:
+      exe: cargo
+      args: [fetch, --locked]
     requirements:
       toolchains: [rust]
     effects:
@@ -277,7 +271,9 @@ agent:
     The Cargo hydration tasks are intentionally agent-authorized because they hydrate the committed
     lockfile only. `Cargo.lock` remains protected and the pressure lane rejects lockfile drift;
     native hydration uses an ignored repository-local cache and container hydration uses an
-    Ota-managed isolated cache; neither task mutates the developer's global Cargo cache.
+    Ota-managed isolated cache; neither task mutates the developer's global Cargo cache. The
+    structured commands retain `--locked` because Ota v1.6.27's typed Cargo hydration does not yet
+    expose lock enforcement.
     The default `verify` task is bounded to non-credentialed source and Gatekeeper controls; do not
     infer model, Qdrant, live-chat, hardware, or shipping readiness from a green result.
   bootstrap:


### PR DESCRIPTION
## Purpose

This draft adds a reviewable Ota contract and a separate non-blocking evidence workflow for a bounded Eris source-verification surface.

The integration is isolated from existing required checks. It uses `pull_request`, `contents: read`, commit-pinned actions, and Ota `v1.6.27` from the contract. It adds no credentials and does not change Eris source behavior.

## Contract-owned surface

- Lock-enforced Cargo hydration into ignored repository-local native and container caches.
- Binary/test build and production-binary Clippy.
- The complete 47-batch `cargo test-full` surface.
- One disposable Markdown-vault read fixture.
- One exact Gatekeeper-allowed fixture.
- One exact Gatekeeper-refused fixture.
- An agent entrypoint and safe-task boundary using `ota tasks --safe --use` and `ota run ... --agent`.
- A digest-pinned Linux container lane for the three portable vault/Gatekeeper controls.

## Retained evidence

- Exact branch revision: `a8237b2cdfcdd651bec6d82f2d7576a531176fb5`
- Exact-head matrix: https://github.com/bobaikato/eris/actions/runs/33692182681

The workflow retains validation, Doctor, task-surface, dry-run, execution, container-image, and exact lane-outcome artifacts. Because the workflow is non-blocking, the retained per-lane outcomes are the evidence source rather than the workflow conclusion alone.

The exact-head artifacts show:

- Ubuntu and macOS both completed all 47 source-owned test batches.
- Both native previews were `READY` / `RUNNABLE` with `execution_started: false`.
- Both native lanes used Ota `v1.6.27` at Core commit `918578d3e0370cc7bb2366b6e831b6f19e58e2a6` and Rust `1.98.0`.
- The container lane passed the vault-read, Gatekeeper-allowed, and Gatekeeper-refused controls using Linux/amd64 Rust 1.95 at `rust@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1`.
- Doctor reported repository posture `risky` but agent posture `ready`; the warnings retain declared network-hydration and execution boundaries.
- `Cargo.lock` and tracked repository files remained unchanged across the selected matrix.

Retained artifact ZIP digests:

- Ubuntu: `sha256:caef86d5d34b6aa4c70b159bf04b5b757d7863ab6ee410d398fe780af188e408`
- macOS: `sha256:436fd4431db5b30e07ef564ef9ee93d144a53f17b1476423fc36885d1bf0a378`
- container: `sha256:147a7879f0fdc51528679a5003d913b2e4b5b85935af5be5f4cab59f508ac81d`
- advisory readiness: `sha256:12bb3e31c95d269d169a7ff9d65f8bd4359f4b7411b12ef00451d98308abc261`

## Repository findings left unchanged

- `cargo fmt --all -- --check` reports existing formatting drift and remains advisory.
- Clippy succeeds with existing warnings; this PR does not reformat or refactor source.
- Hosted Windows execution is excluded because the current tree contains a documentation filename with double quotes that Git cannot check out on an NTFS-backed runner.
- The dynamic `${{ matrix.batch }}` workflow body remains provider-owned CI truth; the contract declares the complete source-owned `cargo test-full` lane instead of fabricating a resolved batch.

## Explicitly not proved

This PR does not prove:

- `llama-server`, Ollama, or GGUF model installation, startup, identity, or compatibility;
- real model inference or grammar enforcement;
- Qdrant readiness, persistence, or semantic-memory correctness;
- live TUI, web, chat, operator-vault, ignition, seal, or real write behavior;
- hardware/GPU profiles, external integrations, or credentials;
- the private `feature/shipping` lifecycle;
- independent modeling of every command inside the source-owned 47-batch shell runner;
- terminal container-cleanup evidence after the ephemeral controls;
- packaging, Windows execution, or repository-wide readiness.